### PR TITLE
Added Build Tools

### DIFF
--- a/Packages/Tools/BuildPhasesPlugins/.swiftpm/xcode/xcshareddata/xcschemes/BuildPhasesPlugins.xcscheme
+++ b/Packages/Tools/BuildPhasesPlugins/.swiftpm/xcode/xcshareddata/xcschemes/BuildPhasesPlugins.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BuildPhasesPlugins"
+               BuildableName = "BuildPhasesPlugins"
+               BlueprintName = "BuildPhasesPlugins"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BuildPhasesPlugins"
+            BuildableName = "BuildPhasesPlugins"
+            BlueprintName = "BuildPhasesPlugins"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Packages/Tools/BuildPhasesPlugins/.swiftpm/xcode/xcshareddata/xcschemes/SwiftLint.xcscheme
+++ b/Packages/Tools/BuildPhasesPlugins/.swiftpm/xcode/xcshareddata/xcschemes/SwiftLint.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SwiftLint"
+               BuildableName = "SwiftLint"
+               BlueprintName = "SwiftLint"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "SwiftLint"
+            BuildableName = "SwiftLint"
+            BlueprintName = "SwiftLint"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/SwiftLint.artifactbundle/LICENSE
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/SwiftLint.artifactbundle/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Realm Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/SwiftLint.artifactbundle/info.json
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/SwiftLint.artifactbundle/info.json
@@ -1,0 +1,15 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "swiftlint": {
+            "version": "0.49.0",
+            "type": "executable",
+            "variants": [
+                {
+                    "path": "swiftlint/bin/swiftlint",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                }
+            ]
+        }
+    }
+}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/SwiftLint.artifactbundle/swiftlint/swiftlint.yml
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/SwiftLint.artifactbundle/swiftlint/swiftlint.yml
@@ -1,0 +1,46 @@
+disabled_rules:
+  - nesting
+  - generic_type_name
+opt_in_rules:
+  - attributes
+  - closure_end_indentation
+  - closure_spacing
+  - empty_count
+  - explicit_init
+  - fatal_error_message
+  - first_where
+  - multiline_parameters
+  - operator_usage_whitespace
+  - overridden_super_call
+  - pattern_matching_keywords
+  - private_outlet
+  - prohibited_super_call
+  - redundant_nil_coalescing
+  - single_test_class
+  - switch_case_on_newline
+  - trailing_closure
+  - unneeded_parentheses_in_closure_argument
+
+# configuration
+large_tuple:
+  warning: 4
+  error: 5
+file_length:
+  warning: 600
+  error: 900
+function_parameter_count:
+  warning: 8
+  error: 9
+identifier_name:
+  excluded:
+    - id
+    - to
+    - in
+    - at
+    - of
+    - up
+    - me
+    - en
+    - ar
+
+reporter: "xcode"

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/info.json
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/info.json
@@ -1,0 +1,15 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "swiftgen": {
+            "type": "executable",
+            "version": "6.6.2",
+            "variants": [
+                {
+                    "path": "swiftgen/bin/swiftgen",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                },
+            ]
+        }
+    }
+}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/CHANGELOG.md
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/CHANGELOG.md
@@ -1,0 +1,1571 @@
+# SwiftGen CHANGELOG
+
+---
+
+## 6.6.2
+
+### Changes in core dependencies of SwiftGen
+
+* [StencilSwiftKit 2.10.1](https://github.com/SwiftGen/StencilSwiftKit/blob/2.10.1/CHANGELOG.md)
+
+### Bug Fixes
+
+* Strings: correctly handle translations containing `\t` (tabs) and other escape sequences.  
+  [David Jennes](https://github.com/djbe)
+  [#985](https://github.com/SwiftGen/SwiftGen/issues/985)
+  [#986](https://github.com/SwiftGen/SwiftGen/issues/986)
+  [#988](https://github.com/SwiftGen/SwiftGen/pull/988)
+  [#998](https://github.com/SwiftGen/SwiftGen/pull/998)
+* Strings: fix the Objective-C template.  
+  [David Jennes](https://github.com/djbe)
+  [#990](https://github.com/SwiftGen/SwiftGen/issues/990)
+  [#991](https://github.com/SwiftGen/SwiftGen/pull/991)
+
+### Internal Changes
+
+* Strings: greatly improve the performance of the new comments parser.  
+  [David Jennes](https://github.com/djbe)
+  [#987](https://github.com/SwiftGen/SwiftGen/issues/987)
+  [#989](https://github.com/SwiftGen/SwiftGen/pull/989)
+
+## 6.6.1
+
+### Changes in core dependencies of SwiftGen
+
+* [Stencil 0.15.1](https://github.com/kylef/Stencil/blob/0.15.1/CHANGELOG.md)
+
+### Bug Fixes
+
+* CLI: fixed `run parser` when no `params` or `options` are provided (broken in 6.6.0).  
+  [David Jennes](https://github.com/djbe)
+  [#983](https://github.com/SwiftGen/SwiftGen/pull/983)
+* JSON/Plist/YAML: fixed code generation (broken in 6.6.0).  
+  [David Jennes](https://github.com/djbe)
+  [#983](https://github.com/SwiftGen/SwiftGen/pull/983)
+
+## 6.6.0
+
+### Changes in core dependencies of SwiftGen
+
+* [StencilSwiftKit 2.10.0](https://github.com/SwiftGen/StencilSwiftKit/blob/2.10.0/CHANGELOG.md)
+* [Stencil 0.15.0](https://github.com/kylef/Stencil/blob/0.15.0/CHANGELOG.md)
+
+### Breaking Changes
+
+* Strings: due to the bugfix for fallback translations, custom `lookupFunction`s will need to accept 3 arguments (table, key and value), up from 2 arguments (table and key).  
+  [David Jennes](https://github.com/djbe)
+  [#964](https://github.com/SwiftGen/SwiftGen/pull/964)
+
+### Deprecations
+
+* The Swift 4 templates are now deprecated. This means we will no longer test if the generated output is valid Swift code. We will still try to keep these up-to-date with context changes.  
+  [David Jennes](https://github.com/djbe)
+  [#955](https://github.com/SwiftGen/SwiftGen/pull/955)
+* Our spacing & trimming "hack" is now considered deprecated, and in the next major version we'll switch to Stencil's new "smart" trimming behaviour (see [Stencil documentation](https://stencil.fuller.li/en/latest/templates.html#whitespace-control) for more information). Our built-in templates have already switched to this modern behaviour, you can try it with your own templates by using the `--experimental-modern-spacing` flag.  
+  [David Jennes](https://github.com/djbe)
+  [#977](https://github.com/SwiftGen/SwiftGen/pull/977)
+* XCAssets: some old properties & parameters are being deprecated. Read the migration guides for more information.  
+  [David Jennes](https://github.com/djbe)
+  [#978](https://github.com/SwiftGen/SwiftGen/pull/978)
+
+### New Features
+
+* Added support for `--quiet/-q` flag, to suppress all logs (except errors).  
+  [Andre113](https://github.com/Andre113)
+  [#823](https://github.com/SwiftGen/SwiftGen/issues/823)
+  [#846](https://github.com/SwiftGen/SwiftGen/pull/846)
+* CoreData: ensure generated classes are `final` when model isn't abstract.  
+  [grsouza](https://github.com/grsouza)
+  [#940](https://github.com/SwiftGen/SwiftGen/pull/940)
+* Added `.artifactbundle` release uploads to support SE-0325 Swift Plugins.  
+  [nicorichard](https://github.com/nicorichard)
+  [#913](https://github.com/SwiftGen/SwiftGen/issues/913)
+  [#926](https://github.com/SwiftGen/SwiftGen/pull/926)
+* Strings: added support for `.strings` files comments. The built-in templates will now use them for comments instead of the translation of a key.  
+  [CraigSiemens](https://github.com/CraigSiemens)
+  [#563](https://github.com/SwiftGen/SwiftGen/issues/563)
+  [#813](https://github.com/SwiftGen/SwiftGen/pull/813)
+* CoreData: support derived attributes.  
+  [David Jennes](https://github.com/djbe)
+  [#928](https://github.com/SwiftGen/SwiftGen/issues/928)
+  [#961](https://github.com/SwiftGen/SwiftGen/pull/961)
+* Added an experimental flag `--experimental-modern-spacing` to enable modern spacing control, see [Stencil documentation](https://stencil.fuller.li/en/latest/templates.html#whitespace-control) for more information. It will disable our own trimming "hack", and enable Stencil's "smart" trimming.  
+  [David Jennes](https://github.com/djbe)
+  [#977](https://github.com/SwiftGen/SwiftGen/pull/977)
+* XCAssets & Fonts: added support for SwiftUI. You can now easily access colors images, symbols and custom fonts from your SwiftUI code.  
+  [David Jennes](https://github.com/djbe)
+  [#979](https://github.com/SwiftGen/SwiftGen/pull/979)
+
+### Bug Fixes
+
+* CoreData: ensure fetched properties use the right class name.  
+  [David Jennes](https://github.com/djbe)
+  [#936](https://github.com/SwiftGen/SwiftGen/issues/936)
+  [#960](https://github.com/SwiftGen/SwiftGen/pull/960)
+* CoreData: now correctly generate code for `OptionSet` attributes by setting the "User Info" key `nonOptionalInit` to true.  
+  [David Jennes](https://github.com/djbe)
+  [#727](https://github.com/SwiftGen/SwiftGen/issues/727)
+  [#965](https://github.com/SwiftGen/SwiftGen/pull/965)
+* Fonts: fix file-type check in sandboxed environments.  
+  [David Jennes](https://github.com/djbe)
+  [#952](https://github.com/SwiftGen/SwiftGen/issues/952)
+  [#967](https://github.com/SwiftGen/SwiftGen/pull/967)
+* Fixed Stencil tags that can refer to other templates, such as the `include` tag.  
+  [David Jennes](https://github.com/djbe)
+  [#950](https://github.com/SwiftGen/SwiftGen/issues/950)
+  [#959](https://github.com/SwiftGen/SwiftGen/pull/959)
+* Strings: now correctly provides the default translation as fallback.  
+  [David Jennes](https://github.com/djbe)
+  [#381](https://github.com/SwiftGen/SwiftGen/issues/381)
+  [#937](https://github.com/SwiftGen/SwiftGen/issues/937)
+  [#964](https://github.com/SwiftGen/SwiftGen/pull/964)
+
+### Internal Changes
+
+* Updated GitHub Actions to use macOS 12.  
+  [David Jennes](https://github.com/djbe)
+  [#956](https://github.com/SwiftGen/SwiftGen/pull/956)
+* Update dependencies such as SwiftLint (and enable some extra rules).  
+  [David Jennes](https://github.com/djbe)
+  [#968](https://github.com/SwiftGen/SwiftGen/pull/968)
+  [#970](https://github.com/SwiftGen/SwiftGen/pull/970)
+* Implement automatic publication using GitHub Actions.  
+  [David Jennes](https://github.com/djbe)
+  [#969](https://github.com/SwiftGen/SwiftGen/pull/969)
+* Switched from [Commander](https://github.com/kylef/Commander) to Swift's own [ArgumentParser](https://github.com/apple/swift-argument-parser) library.  
+  [David Jennes](https://github.com/djbe)
+  [#966](https://github.com/SwiftGen/SwiftGen/pull/966)
+* Updated to Stencil 0.15 and StencilSwiftKit 2.10.  
+  [David Jennes](https://github.com/djbe)
+  [#977](https://github.com/SwiftGen/SwiftGen/pull/977)
+* Added `Difference` library for easier testing of context differences.  
+  [David Jennes](https://github.com/djbe)
+  [#981](https://github.com/SwiftGen/SwiftGen/pull/981)
+
+## 6.5.1
+
+### Bug Fixes
+
+* Workaround for Mint that does not yet support the SPM resource bundle.  
+  [@tid-kijyun](https://github.com/tid-kijyun)
+  [#883](https://github.com/SwiftGen/SwiftGen/issues/883)
+  [#885](https://github.com/SwiftGen/SwiftGen/pull/885)
+
+### Internal Changes
+
+* Tweak release script to handle both universal & slim builds.  
+  [David Jennes](https://github.com/djbe)
+  [#884](https://github.com/SwiftGen/SwiftGen/pull/884)
+
+## 6.5.0
+
+### Changes in core dependencies of SwiftGen
+
+* [StencilSwiftKit 2.8.0](https://github.com/SwiftGen/StencilSwiftKit/blob/2.8.0/CHANGELOG.md)
+* [Stencil 0.14.1](https://github.com/kylef/Stencil/blob/0.14.1/CHANGELOG.md)
+
+### New Features
+
+* XCAssets: the parser now supports Symbol sets, so you can safely use custom symbols.  
+  [David Jennes](https://github.com/djbe)
+  [#788](https://github.com/SwiftGen/SwiftGen/pull/788)
+* XCAssets: you can now provide a trait collection when initializing a color or image asset (on iOS/tvOS).  
+  [David Jennes](https://github.com/djbe)
+  [#790](https://github.com/SwiftGen/SwiftGen/pull/790)
+* Files: Add new parser for accessing loose files in your project.  
+  [Mike Gray](https://github.com/mgray88)
+  [David Jennes](https://github.com/djbe)
+  [#665](https://github.com/SwiftGen/SwiftGen/issues/665)
+  [#734](https://github.com/SwiftGen/SwiftGen/pull/734)
+* Colors: The XML parser now supports Android color aliases (using `@color/...`).  
+  [David Jennes](https://github.com/djbe)
+  [#562](https://github.com/SwiftGen/SwiftGen/issues/562)
+  [#797](https://github.com/SwiftGen/SwiftGen/pull/797)
+* Support M1 and Intel devices (universal binary).  
+  [David Jennes](https://github.com/djbe)
+  [#805](https://github.com/SwiftGen/SwiftGen/issues/805)
+  [#880](https://github.com/SwiftGen/SwiftGen/pull/880)
+
+### Bug Fixes
+
+* XCAssets: fixed some availability annotations that were incorrect.  
+  [David Jennes](https://github.com/djbe)
+  [#789](https://github.com/SwiftGen/SwiftGen/pull/789)
+* Strings: `objc-h` template now emits valid documentation comments.  
+  [@szotp](https://github.com/szotp)
+  [#822](https://github.com/SwiftGen/SwiftGen/pull/822)
+* Generate `xcfilelist`: Adds the template file path to the inputs `xcfilelist` (for custom templates).  
+  [Craig Siemens](https://github.com/CraigSiemens)
+  [#815](https://github.com/SwiftGen/SwiftGen/pull/815)
+* Strings: built-in templates now have better handling of multi-line translations.  
+  [@mrackwitz](https://github.com/mrackwitz)
+  [#774](https://github.com/SwiftGen/SwiftGen/pull/774)
+
+### Internal Changes
+
+* Switch to GitHub Actions.  
+  [#794](https://github.com/SwiftGen/SwiftGen/pull/794)
+  [David Jennes](https://github.com/djbe)
+* Switched the whole project over to use Swift Package Manager, restructuring some of the internals in the process.  
+  [David Jennes](https://github.com/djbe)
+  [#793](https://github.com/SwiftGen/SwiftGen/pull/793)
+* Updated dependencies and gems, particularyly PathKit to support Xcode 13.  
+  [David Jennes](https://github.com/djbe)
+  [Jared Sorge](https://github.com/jsorge)
+  [#827](https://github.com/SwiftGen/SwiftGen/pull/827)
+  [#874](https://github.com/SwiftGen/SwiftGen/pull/874)
+  [#879](https://github.com/SwiftGen/SwiftGen/pull/879)
+
+## 6.4.0
+
+### New Features
+
+* The built-in templates will now correctly handle Swift Package Manager resources, using `Bundle.module` if it's available. As before, you can override the used `Bundle` using the `bundle` or `lookupFunction` template parameters.  
+  [Arnaud Dorgans](https://github.com/arnauddorgans)
+  [#763](https://github.com/SwiftGen/SwiftGen/pull/763)
+* Added `config generate-xcfilelist` subcommand to generate input and output `xcfilelist`s based on your configuration file. These files should then be used in an Xcode build step that executes `swiftgen config run`. Don't forget to regenerate the file lists after adding/removing resources in your project in a way that might impact them.  
+  [@CraigSiemens](https://github.com/CraigSiemens)
+  [#441](https://github.com/SwiftGen/SwiftGen/issues/441)
+* Colors: the XML parser now accepts a `colorFormat` option, used to change the color format. The default format is `rgba`.  
+  [@kevinstier](https://github.com/kevinstier)
+  [#562](https://github.com/SwiftGen/SwiftGen/issues/562)
+  [#768](https://github.com/SwiftGen/SwiftGen/pull/768)
+* IB: Added support for instantiating scenes while providing a `creator` block, commonly used for dependency injection. This feature is available in generated code starting from iOS 13, tvOS 13 and macOS 10.15.  
+  [@matsune](https://github.com/matsune)
+  [David Jennes](https://github.com/djbe)
+  [#778](https://github.com/SwiftGen/SwiftGen/pull/778)
+
+### Bug Fixes
+
+* Plist: Update the parsing strategy (using `Codable`) to fix parsing of `Bool` values as `Integer` in some cases.  
+  [@fortmarek](https://github.com/fortmarek)
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#779](https://github.com/SwiftGen/SwiftGen/pull/779)
+* JSON/Plist/YAML: fixed issue with `inline` templates which incorrectly generated `1`/`0` as values, instead of `true`/`false` as expected.  
+  [David Jennes](https://github.com/djbe)
+  [#779](https://github.com/SwiftGen/SwiftGen/pull/779)
+  [#783](https://github.com/SwiftGen/SwiftGen/pull/783)
+* JSON: the parser now correctly recognizes `0` and `1` as `Int` (instead of `Bool`).  
+  [David Jennes](https://github.com/djbe)
+  [#786](https://github.com/SwiftGen/SwiftGen/pull/786)
+
+### Internal Changes
+
+* Update the Swift version in `.swift-version` so that the right version is used when building manually (using `swiftenv`).  
+  [@cfiken](https://github.com/cfiken)
+  [#764](https://github.com/SwiftGen/SwiftGen/issues/764)
+* Update Yams from `3.0.0` to `4.0.0`.  
+  [@hungrxyz](https://github.com/hungrxyz)
+  [#772](https://github.com/SwiftGen/SwiftGen/issues/772)
+* Updated Pods and Gems dependencies, and Xcode 12.  
+  [David Jennes](https://github.com/djbe)
+  [#782](https://github.com/SwiftGen/SwiftGen/pull/782)
+
+## 6.3.0
+
+### Deprecations
+
+* Fonts: the generated `Font` typealias (to `UIFont`/`NSFont`) is deprecated and will be removed in the next major release.  
+  [David Jennes](https://github.com/djbe)
+  [#728](https://github.com/SwiftGen/SwiftGen/pull/728)
+
+### New Features
+
+* Strings: support for plurals declared in `.stringsdict` files.  
+  [Florian Fittschen](https://github.com/ffittschen)
+  [#184](https://github.com/SwiftGen/SwiftGen/issues/184)
+  [#634](https://github.com/SwiftGen/SwiftGen/pull/634)
+* Fonts: the templates now support a new `fontTypeName` template parameter that you can use to change the name of the `struct` representing a font to something else.  
+  [David Jennes](https://github.com/djbe)
+  [#728](https://github.com/SwiftGen/SwiftGen/pull/728)
+* Fonts: the templates now support a new `fontAliasName` that you can use to change the `typealias`'s name from `Font` to something else. For example: this is useful when working with SwiftUI which already defines a `Font` type. Note that as this `typealias` is deprecated (see deprecations above), this template parameter will also be removed in the next major release.  
+  [David Jennes](https://github.com/djbe)
+  [#647](https://github.com/SwiftGen/SwiftGen/issues/647)
+  [#728](https://github.com/SwiftGen/SwiftGen/pull/728)
+* CoreData: Deprecates `fetchRequest()` and adds `makeFetchRequest()` to avoid ambiguous function usage.  
+  [David Rothera](https://github.com/davidrothera)
+  [#726](https://github.com/SwiftGen/SwiftGen/pull/726)
+* XCAssets: image assets now load faster on macOS if they're in the `main` bundle. MacOS only provides a caching mechanism for images in the `main` bundle, for other cases you may need to provide your own caching mechanism as needed.  
+  [David Jennes](https://github.com/djbe)
+  [#648](https://github.com/SwiftGen/SwiftGen/issues/648)
+  [#733](https://github.com/SwiftGen/SwiftGen/pull/733)
+* Fonts/IB/JSON/Plist/Strings/XCAssets: all templates that load data at runtime from a bundle now support a `bundle` template parameter, which you can use to override the bundle from which resources are loaded. Check out the [template specific documentation](Documentation/templates/) for more information. For an in-depth explanation, also check the [customize loading of resources](Documentation/Articles/Customize-loading-of-resources.md) article.  
+  [David Jennes](https://github.com/djbe)
+  [#737](https://github.com/SwiftGen/SwiftGen/pull/737)
+* Fonts/IB/JSON/Plist: Similar to the `strings` templates, these templates now support a `lookupFunction` template parameter, which allows you to provide your own resource lookup mechanism at runtime. Check the [template specific documentation](Documentation/templates/) for more information. For an in-depth explanation, also check the [customize loading of resources](Documentation/Articles/Customize-loading-of-resources.md) article.  
+  [David Jennes](https://github.com/djbe)
+  [#738](https://github.com/SwiftGen/SwiftGen/pull/738)
+
+### Bug Fixes
+
+* Strings: fix incorrect interpretation of format placeholders when there were missing positional parameters (e.g. `"%2$@"` without a `%1$…` defined).  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#634](https://github.com/SwiftGen/SwiftGen/pull/634)
+
+## 6.2.1
+
+There are no major changes in this release, although JSON & Plist template writers may want to read the [small migration guide](Documentation/SwiftGenKit%20Contexts/MigrationGuide.md##swiftgen-621-migration-guide) to prepare for upcoming context changes.
+
+### Deprecations
+
+* JSON & Plist: if you wrote your own templates, know that the `documents` property of a file has been deprecated in favour of `document`. The old `documents` property will be removed in the next major release.  
+  [David Jennes](https://github.com/djbe)
+  [#702](https://github.com/SwiftGen/SwiftGen/pull/702)
+  [#732](https://github.com/SwiftGen/SwiftGen/pull/732)
+
+### Bug Fixes
+
+* Prevent generating `default.profraw` (code coverage) files.  
+  [David Jennes](https://github.com/djbe)
+  [#722](https://github.com/SwiftGen/SwiftGen/pull/722)
+* JSON/Plist/YAML: Fix issue with homogeneous `Array`s in the Inline templates (such as `[String`]).  
+  [#687](https://github.com/SwiftGen/SwiftGen/pull/687)
+  [@fjtrujy](https://github.com/fjtrujy)
+* Avoid breaking the system swift installation when installing SwiftGen via Homebrew on macOS 10.14.4 or higher.  
+  [David Jennes](https://github.com/djbe)
+  [#686](https://github.com/SwiftGen/SwiftGen/issues/686)
+  [#730](https://github.com/SwiftGen/SwiftGen/pull/730)
+
+### Internal Changes
+
+* Parsers are now executed in parallel, making SwiftGen faster when multiple parsers are used. Note: only applies when using a configuration file.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#699](https://github.com/SwiftGen/SwiftGen/issues/699)
+* Use `JSONSerialization` instead of `Yams` for parsing JSONs, making the `json` parser faster.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#698](https://github.com/SwiftGen/SwiftGen/issues/698)
+* JSON/Plist/YAML: Lazily evaluate `metadata` of documents, making SwiftGen faster if the `metadata` field is never used in a template.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#700](https://github.com/SwiftGen/SwiftGen/issues/700)
+
+## 6.2.0
+
+⚠️ This minor version contains a lot of deprecations that may apply to your configuration and how you use SwiftGen. With the exception of `swift3` templates (which have been removed), everything should still work as before. But be warned that all features marked as deprecated will be removed in SwiftGen 7.0.
+
+Read the [SwiftGen 6.2 Migration Guide](Documentation/MigrationGuide.md#migrating-to-swiftgen-62) for a list of changes you'll need to apply.
+
+### Breaking Changes
+
+* As Swift 3 is officially no longer maintained, we're obsoleting the Swift 3 templates and they are no longer included with SwiftGen. You can still use the old swift 3 templates by getting them from older SwiftGen versions, or from GitHub by browsing older tags.  
+  [David Jennes](https://github.com/djbe)
+  [#601](https://github.com/SwiftGen/SwiftGen/pull/601)
+  [#691](https://github.com/SwiftGen/SwiftGen/pull/691)
+
+### Deprecations
+
+* XCAssets: the `colorAliasName` and `imageAliasName` template parameters are now deprecated and will be removed in the next major release.  
+  [David Jennes](https://github.com/djbe)
+  [#614](https://github.com/SwiftGen/SwiftGen/pull/614)
+* The use of `swiftgen <parser>` (e.g. `swiftgen strings`, `swiftgen xcassets`, …) command line for running individual parsers is now deprecated in favor of `swiftgen run <parser>`. See "New Features" below.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#705](https://github.com/SwiftGen/SwiftGen/pull/705)
+* The subcommand `swiftgen templates` has been renamed `swiftgen template` (singular); the plural form of the command has been deprecated and will be removed in next major version.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#697](https://github.com/SwiftGen/SwiftGen/pull/697)
+* The ability for SwiftGen to search custom named templates in `~/Library/Application Support` has been deprecated and will be removed in SwiftGen 7.0. This little known feature made SwiftGen dependent on the machine it was running on. Use `templatePath` to reference custom templates by path instead.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#717](https://github.com/SwiftGen/SwiftGen/pull/717)
+
+### New Features
+
+* Invoking individual parsers from the command line is now done via `swiftgen run <parser>`.  We still highly recommend to use a configuration file for flexibility and performance reasons in your projects, and only use `swiftgen run <parser>` for things like quick iterations when writing your own custom templates.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#705](https://github.com/SwiftGen/SwiftGen/pull/705)
+* You can now easily create a new config file using `swiftgen config init`. This will create an example and commented config file and open it to let you edit it to your needs.  _Note that the generated config file is static content which doesn't take the user's project into account (though that might change in the future)_.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#694](https://github.com/SwiftGen/SwiftGen/pull/694)
+* You can now use `swiftgen template doc [parser] [templateName]` on the command line to quickly open the documentation for templates on GitHub directly from your terminal.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#697](https://github.com/SwiftGen/SwiftGen/pull/697)
+* Each parser now accepts an `options` dictionary, with which you can set internal parser settings to change its behaviour. See the parser's specific documentation for available options.  
+  [David Jennes](https://github.com/djbe)
+  [#587](https://github.com/SwiftGen/SwiftGen/pull/587)
+  [#597](https://github.com/SwiftGen/SwiftGen/pull/597)
+* Strings: the parser now accepts a `separator` option, used to split keys into structured components. The default separator remains `.`. For more information, check the [parser's documentation](Documentation/Parsers/strings.md#customization).  
+  [David Jennes](https://github.com/djbe)
+  [#576](https://github.com/SwiftGen/SwiftGen/issues/576)
+  [#588](https://github.com/SwiftGen/SwiftGen/pull/588)
+* Core Data: the built-in templates now support an optional `extraImports` parameter. With this you can provide a list of modules to additionally import, for when you have properties with types from external modules. For more information, check the [template's documentation](Documentation/templates/coredata/swift4.md#customization).  
+  [David Jennes](https://github.com/djbe)
+  [#591](https://github.com/SwiftGen/SwiftGen/issues/591)
+  [#592](https://github.com/SwiftGen/SwiftGen/pull/592)
+* Core Data: the built-in templates now support `RawRepresentable` attributes (such as `enum`, `OptionSet`, …). They'll check the "User Info" of an attribute for a `RawType` key, which should be set to the type name you want to use for that attribute. To avoid optional attributes, you can also add the `unwrapOptional` user info key. For more information, check the [template's documentation](Documentation/templates/coredata/swift4.md#userinfo-keys).  
+  [David Jennes](https://github.com/djbe)
+  [#566](https://github.com/SwiftGen/SwiftGen/issues/566)
+  [#609](https://github.com/SwiftGen/SwiftGen/issues/609)
+  [#593](https://github.com/SwiftGen/SwiftGen/pull/593)
+  [#610](https://github.com/SwiftGen/SwiftGen/pull/610)
+* Strings: the built-in templates now accept a parameter `lookupFunction` for customizing the localization function, check the [template documentation](Documentation/templates/strings/) for more information.  
+  [Steven Magdy](https://github.com/StevenMagdy)
+  [426](https://github.com/SwiftGen/SwiftGen/issues/426)
+  [468](https://github.com/SwiftGen/SwiftGen/issues/468)
+  [573](https://github.com/SwiftGen/SwiftGen/pull/573)
+  [716](https://github.com/SwiftGen/SwiftGen/pull/716)
+* Strings: templates to generate Objective-C. Please check [the template's documentation](Documentation/templates/strings/objc.md) for more information.  
+  [Eric Slosser](https://github.com/Mr-Fixit)
+  [SwiftGen/SwiftGen#378](https://github.com/SwiftGen/SwiftGen/pull/378)
+* XCAssets: the parser now supports AR Resource Groups, together with reference images and objects.  
+  [David Jennes](https://github.com/djbe)
+  [#614](https://github.com/SwiftGen/SwiftGen/pull/614)
+* Templates: Bundle now use static property on BundleToken for better performance.  
+  [shuoli84](https://github.com/shuoli84)
+  [#623](https://github.com/SwiftGen/SwiftGen/issues/623)
+* All parsers now have built-in Swift 5 templates.  
+  [David Jennes](https://github.com/djbe)
+  [#595](https://github.com/SwiftGen/SwiftGen/issues/595)
+  [#600](https://github.com/SwiftGen/SwiftGen/pull/600)
+* Most templates now accept a parameter to force having the file name used as namespace (`enum <FileName>`) in generated code _even if_ there's only one single input file.  
+  [Viktoras Laukevičius](https://github.com/viktorasl)
+  [#669](https://github.com/SwiftGen/SwiftGen/issues/669)
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#693](https://github.com/SwiftGen/SwiftGen/pull/693)
+
+### Bug Fixes
+
+* SwiftGen now properly shows a better help message and the command usage when running an incomplete command, instead of complaining about a config file.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#706](https://github.com/SwiftGen/SwiftGen/pull/706)
+* XCAssets: improved the performance for color assets by caching the resolved colors.  
+  [David Jennes](https://github.com/djbe)
+  [#578](https://github.com/SwiftGen/SwiftGen/issues/578)
+  [#589](https://github.com/SwiftGen/SwiftGen/pull/589)
+* Core Data: `entityName` is now correctly a `class var` instead of a `class func`.  
+  [David Jennes](https://github.com/djbe)
+  [#590](https://github.com/SwiftGen/SwiftGen/pull/590)
+* Strings: we now correctly generate the type `Any` (instead of `String`) for `%@` placeholders.  
+  [David Jennes](https://github.com/djbe)
+  [620](https://github.com/SwiftGen/SwiftGen/issues/620)
+* Colors: Reduce initializer type inference for improved compilation performance.  
+  [Markus Faßbender](https://github.com/dermaaarkus)
+  [#663](https://github.com/SwiftGen/SwiftGen/issues/663)
+* Config Lint: fix config lint not processing relative paths containing ".." correctly.  
+  [Wolfgang Lutz](https://github.com/Lutzifer)
+  [#688](https://github.com/SwiftGen/SwiftGen/issues/688)
+* Core Data: the generated code was missing `,` (comma) for fetch requests with multiple arguments.  
+  [David Jennes](https://github.com/djbe)
+  [#692](https://github.com/SwiftGen/SwiftGen/pull/692)
+* Colors: Fix compile time warning when long expression type checking is enabled.  
+  [Ryan Mason-Davies](https://github.com/iotize)
+  [#704](https://github.com/SwiftGen/SwiftGen/issues/704)
+  [#710](https://github.com/SwiftGen/SwiftGen/pull/710)
+
+### Internal Changes
+
+* The main branch of the repository has been renamed from `master` to `stable`. If you pointed your `Podfile` or dependency managment tool to `master` instead of an official release/tag, you will have to update the branch name in your dependency file.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#714](https://github.com/SwiftGen/SwiftGen/pull/714)
+* Documentation: Improved doc for creating custom templates, and added a Documentation Table of Contents.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#713](https://github.com/SwiftGen/SwiftGen/pull/713)
+* Refactoring: Reduce globals & rearrange CLI code.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#586](https://github.com/SwiftGen/SwiftGen/pull/586)
+* Moved generated test output files into subdirectories per template.  
+  [David Jennes](https://github.com/djbe)
+  [#598](https://github.com/SwiftGen/SwiftGen/pull/598)
+* Compile generated output using configuration files for easier management.  
+  [David Jennes](https://github.com/djbe)
+  [#365](https://github.com/SwiftGen/SwiftGen/issues/365)
+  [#599](https://github.com/SwiftGen/SwiftGen/pull/599)
+* XCAssets: renamed the catalogs we use for sample code & testing to avoid some confusion.  
+  [David Jennes](https://github.com/djbe)
+  [#613](https://github.com/SwiftGen/SwiftGen/pull/613)
+* Update SwiftLint and enable some extra SwiftLint rules.  
+  [David Jennes](https://github.com/djbe)
+  [#617](https://github.com/SwiftGen/SwiftGen/pull/617)
+* Some CI fixes related to software versions.  
+  [Patrick Nollet](https://github.com/PatrickNLT)
+  [#645](https://github.com/SwiftGen/SwiftGen/pull/645)
+* Updated to CocoaPods 1.9.0.  
+  [David Jennes](https://github.com/djbe)
+  [#619](https://github.com/SwiftGen/SwiftGen/pull/619)
+* Updated Pods and Gems dependencies.  
+  [David Jennes](https://github.com/djbe)
+  [#684](https://github.com/SwiftGen/SwiftGen/pull/684)
+
+## 6.1.0
+
+### Changes in core dependencies of SwiftGen
+
+* [StencilSwiftKit 2.7.2](https://github.com/SwiftGen/StencilSwiftKit/blob/2.7.2/CHANGELOG.md)
+* [Stencil 0.13.1](https://github.com/kylef/Stencil/blob/0.13.1/CHANGELOG.md)
+
+### New Features
+
+* Adds support for generating code from Core Data models.  
+  [Grant Butler](https://github.com/grantjbutler)
+  [David Jennes](https://github.com/djbe)
+  [Igor Palaguta](https://github.com/Igor-Palaguta)
+  [#455](https://github.com/SwiftGen/SwiftGen/pull/455)
+  [#567](https://github.com/SwiftGen/SwiftGen/pull/567)
+  [#575](https://github.com/SwiftGen/SwiftGen/pull/575)
+  [#581](https://github.com/SwiftGen/SwiftGen/pull/581)
+  [#45](https://github.com/SwiftGen/SwiftGen/issues/45)
+  [#185](https://github.com/SwiftGen/SwiftGen/issues/185)
+  [#191](https://github.com/SwiftGen/SwiftGen/pull/191)
+  [#195](https://github.com/SwiftGen/SwiftGen/pull/195)
+* Config: expand environment variables in YAML files.  
+  [Wolfgang Lutz](https://github.com/lutzifer)
+  [#355](https://github.com/SwiftGen/SwiftGen/issues/355)
+  [#564](https://github.com/SwiftGen/SwiftGen/pull/564)
+* Each parser now accepts a `filter` option, which accepts a regular expression for filtering input paths. The filter is applied to individual paths as well as when the parser recurses into directories.  
+  [David Jennes](https://github.com/djbe)
+  [#383](https://github.com/SwiftGen/SwiftGen/issues/383)
+  [#570](https://github.com/SwiftGen/SwiftGen/pull/570)
+
+### Bug Fixes
+
+* Colors: Fix an issue where the `public` access modifier was not being added correctly in the `literals-swift3` and `literals-swift4` templates when the `publicAccess` parameter was specified. Also remove some uneccessary `public` access modifiers from the `swift3` and `swift4` templates.  
+  [Isaac Halvorson](https://github.com/hisaac)
+  [#549](https://github.com/SwiftGen/SwiftGen/pull/549)
+
+### Internal Changes
+
+* Resolve path if the binary is a symbolic link in order to find bundled templates.  
+  [Liquidsoul](https://github.com/liquidsoul)
+  [#559](https://github.com/SwiftGen/SwiftGen/issues/559)
+* Update to SwiftLint 0.30.1 and enable some extra SwiftLint rules.  
+  [David Jennes](https://github.com/djbe)
+  [#574](https://github.com/SwiftGen/SwiftGen/pull/574)
+  [#583](https://github.com/SwiftGen/SwiftGen/pull/583)
+
+## 6.0.2
+
+### Changes in core dependencies of SwiftGen
+
+* [StencilSwiftKit 2.7.1](https://github.com/SwiftGen/StencilSwiftKit/blob/2.7.1/CHANGELOG.md)
+* [Stencil 0.13.1](https://github.com/kylef/Stencil/blob/0.13.1/CHANGELOG.md)
+
+### Bug Fixes
+
+* Strings: rolled back the changes in #503, to ensure `%%` is correctly unescaped.  
+  [David Jennes](https://github.com/djbe)
+  [#542](https://github.com/SwiftGen/SwiftGen/pull/542)
+* Strings: generate the correct types for `%c` and `%p`.  
+  [David Jennes](https://github.com/djbe)
+  [#543](https://github.com/SwiftGen/SwiftGen/pull/543)
+* SPM/Mint: SwiftGen now provides correct version information, instead of "0.0".  
+  [David Jennes](https://github.com/djbe)
+  [#544](https://github.com/SwiftGen/SwiftGen/pull/544)
+
+## 6.0.1
+
+### Changes in core dependencies of SwiftGen
+
+* [StencilSwiftKit 2.7.1](https://github.com/SwiftGen/StencilSwiftKit/blob/2.7.1/CHANGELOG.md)
+* [Stencil 0.13.1](https://github.com/kylef/Stencil/blob/0.13.1/CHANGELOG.md)
+
+### Bug Fixes
+
+* IB: Fix missing `import AppKit`/`import UIKit` in some rare cases.  
+  [David Jennes](https://github.com/djbe)
+  [#515](https://github.com/SwiftGen/SwiftGen/issues/515)
+  [#519](https://github.com/SwiftGen/SwiftGen/pull/519)
+* IB: Fix issue with segues-swift4 template when compiled with Swift 4.2 on macOS.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#515](https://github.com/SwiftGen/SwiftGen/issues/515)
+  [#518](https://github.com/SwiftGen/SwiftGen/pull/518)
+* SPM/Mint: Update the Stencil version to 0.13.1.  
+  [David Jennes](https://github.com/djbe)
+  [#527](https://github.com/SwiftGen/SwiftGen/pull/527)
+* Ensure the `templates` subcommand properly works with the deprecated `storyboards` subcommand.  
+  [David Jennes](https://github.com/djbe)
+  [#525](https://github.com/SwiftGen/SwiftGen/issues/525)
+  [#530](https://github.com/SwiftGen/SwiftGen/pull/530)
+* Ensure configuration file errors show as red in Xcode.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#516](https://github.com/SwiftGen/SwiftGen/issues/516)
+  [#533](https://github.com/SwiftGen/SwiftGen/pull/533)
+* Strings: Ensure the parser correctly handles keys ending with a `.` and empty key components.  
+  [David Jennes](https://github.com/djbe)
+  [#528](https://github.com/SwiftGen/SwiftGen/issues/528)
+  [#531](https://github.com/SwiftGen/SwiftGen/pull/531)
+
+### Internal Changes
+
+* Integrated Danger to help on contributions by giving automatic feedback.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#520](https://github.com/SwiftGen/SwiftGen/issues/520)
+  [#524](https://github.com/SwiftGen/SwiftGen/issues/524)
+
+## 6.0.0
+
+⚠️ This major version is a big milestone in which a lot of refactoring and cleaning has been done. Many features added over previous releases have been reworked and unified, while also preparing SwiftGen for future additions. This means that you'll need to adapt your configuration files (or command line invocations) and custom templates to work with this new major version.
+
+Read the [SwiftGen 6.0 Migration Guide](Documentation/MigrationGuide.md#migrating-to-swiftgen-60) for a list of changes you'll need to apply.
+
+### Changes in core dependencies of SwiftGen
+
+* [StencilSwiftKit 2.7.0](https://github.com/SwiftGen/StencilSwiftKit/blob/2.7.0/CHANGELOG.md)
+* [Stencil 0.13.1](https://github.com/kylef/Stencil/blob/0.13.1/CHANGELOG.md)
+
+### Breaking Changes
+
+* Don't normalize string keys while parsing, let all transformation be done on template side. This makes the developer responsible to keep the language file organized, duplications won't be removed.  
+  [Diego Chohfi](https://github.com/dchohfi)
+  [#257](https://github.com/SwiftGen/SwiftGen/issues/257)
+* Remove Swift 2 support.  
+  [David Jennes](https://github.com/djbe)
+  [#420](https://github.com/SwiftGen/SwiftGen/pull/420)
+* Renamed the `storyboards` command to `ib`, to better reflect it's purpose. An alias for `storyboards` still exists, but it will be removed at some point.  
+  [David Jennes](https://github.com/djbe)
+  [#423](https://github.com/SwiftGen/SwiftGen/pull/423)
+* XCAssets: the generated templates won't namespace groups by default anymore, use the `forceProvidesNamespaces` flag to enable this behaviour again.  
+  [jechris](https://github.com/pjechris)
+  [#453](https://github.com/SwiftGen/SwiftGen/issues/453)
+* XCAssets: the templates won't generate any all-values accessors anymore by default. Use the `allValues` flag to enable this behaviour again. Note: this replaces the old `noAllValues` flag (with an inverse behaviour).  
+  [David Jennes](https://github.com/djbe)
+  [#480](https://github.com/SwiftGen/SwiftGen/pull/480)
+* XCAssets: Dropped the deprecated `allValues` constant, use the type specific constants such as `allColors`, `allDataItems` and `allImages`. The default value of `imageAlias` has also been changed from `Image` to `AssetImageTypeAlias`, to be consistent with the other types.  
+  [David Jennes](https://github.com/djbe)
+  [#482](https://github.com/SwiftGen/SwiftGen/pull/482)
+* Interface Builder: split up the storyboards template into 2 parts, one for scenes and one for segues.  
+  [David Jennes](https://github.com/djbe)
+  [#419](https://github.com/SwiftGen/SwiftGen/pull/419)
+
+### New Features
+
+* Add ability to list all custom fonts and register them using `FontFamily.registerAllCustomFonts`.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#394](https://github.com/SwiftGen/SwiftGen/issues/394)
+* Add support for Swift Package Manager and Mint.  
+  [Yonas Kolb](https://github.com/yonaskolb)
+  [#411](https://github.com/SwiftGen/SwiftGen/pull/411)
+* The `swiftgen.yml` config file now accepts multiple outputs for each parser, allowing you to generate multiple outputs from the same files and content. This also means that the `output` parameter is now deprecated, in favour of the `outputs` parameter, and it may be removed in a future version of SwiftGen. Similarly, the `paths` parameter has been renamed to `inputs` for consistency. You can always use `swiftgen config lint` to validate your configuration file.  
+  [David Jennes](https://github.com/djbe)
+  [#424](https://github.com/SwiftGen/SwiftGen/pull/424)
+  [#510](https://github.com/SwiftGen/SwiftGen/pull/510)
+* Use `swiftlint:disable all` in generated files to avoid interference with SwiftLint rules custom to the host project.  
+  [Frederick Pietschmann](https://github.com/fredpi)
+  [David Jennes](https://github.com/djbe)
+  [#409](https://github.com/SwiftGen/SwiftGen/issues/409)
+  [#506](https://github.com/SwiftGen/SwiftGen/issues/506)
+* XCAssets: Added support for `NSDataAssets`.  
+  [Oliver Jones](https://github.com/orj)
+  [#444](https://github.com/SwiftGen/SwiftGen/issues/444)
+* Organised the generated code in sections for better readability, with all generated constants at the top of the file.  
+  [David Jennes](https://github.com/djbe)
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#456](https://github.com/SwiftGen/SwiftGen/pull/456)
+  [#481](https://github.com/SwiftGen/SwiftGen/pull/481)
+* Added support for JSON, Plist and YAML files using the `swiftgen json`, `swiftgen plist` and `swiftgen yaml` commands. The parsed contexts and the generated files for each parser have been kept quite similar, for easier switching between file formats.  
+  [John T McIntosh](https://github.com/johntmcintosh)
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [Peter Livesey](https://github.com/plivesey)
+  [David Jennes](https://github.com/djbe)
+  [#379](https://github.com/SwiftGen/SwiftGen/pull/379)
+  [#359](https://github.com/SwiftGen/SwiftGen/issues/359)
+  [#288](https://github.com/SwiftGen/SwiftGen/pull/288)
+  [#188](https://github.com/SwiftGen/SwiftGen/pull/188)
+  [#493](https://github.com/SwiftGen/SwiftGen/pull/493)
+  [#504](https://github.com/SwiftGen/SwiftGen/pull/504)
+* Updated the playgrounds with the new `json`, `plist` and `yaml` parsers, and updated the other pages to reflect the template changes.  
+  [David Jennes](https://github.com/djbe)
+  [#495](https://github.com/SwiftGen/SwiftGen/pull/495)
+* We're deprecating the old `--template` CLI option in favor of `--templateName`, to better match the naming of the other options and the configuration file. The old `--template` option will remain until the next major version.  
+  [David Jennes](https://github.com/djbe)
+  [#509](https://github.com/SwiftGen/SwiftGen/pull/509)
+
+### Bug Fixes
+
+* Fix memory leak in generated code for Fonts.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#394](https://github.com/SwiftGen/SwiftGen/issues/394)
+* Interface Builder: ensure the templates handle `GLKViewController`, `AVPlayerViewController` and `NSPageController` correctly.  
+  [David Jennes](https://github.com/djbe)
+  [#404](https://github.com/SwiftGen/SwiftGen/issues/404)
+  [#414](https://github.com/SwiftGen/SwiftGen/pull/414)
+* Interface Builder: ensure the parser can handle files with and without "trait variations".  
+  [David Jennes](https://github.com/djbe)
+  [#367](https://github.com/SwiftGen/SwiftGen/issues/367)
+  [#429](https://github.com/SwiftGen/SwiftGen/pull/429)
+* Restrict `SceneType` and `InitialSceneType` to UIViewController when not targeting AppKit. When targeting AppKit, remove superfluous `Any`.  
+  [Darron Schall](https://github.com/darronschall)
+  [#463](https://github.com/SwiftGen/SwiftGen/issues/463)
+  [#464](https://github.com/SwiftGen/SwiftGen/pull/464)
+* Fonts: disable a warning in generated font files for projects with `conditional_returns_on_newlines` SwiftLint rule enabled.  
+  [Ryan Davies](https://github.com/iotize)
+  [#436](https://github.com/SwiftGen/SwiftGen/issues/436)
+  [#465](https://github.com/SwiftGen/SwiftGen/pull/465)
+* Interface Builder: the parser and templates now handle the "Inherit module from target" setting.  
+  [David Jennes](https://github.com/djbe)
+  [#435](https://github.com/SwiftGen/SwiftGen/issues/435)
+  [#485](https://github.com/SwiftGen/SwiftGen/pull/485)
+* Strings: the parser now correctly handles formats such as `% d` and `%#x`.  
+  [David Jennes](https://github.com/djbe)
+  [#502](https://github.com/SwiftGen/SwiftGen/pull/502)
+* Strings: ensure strings without arguments are not processed using `String(format:)`.  
+  [David Jennes](https://github.com/djbe)
+  [#503](https://github.com/SwiftGen/SwiftGen/pull/503)
+
+### Internal Changes
+
+* Migrated to CircleCI 2.0.  
+  [David Jennes](https://github.com/djbe)
+  [#403](https://github.com/SwiftGen/SwiftGen/pull/403)
+* Switched to using SwiftLint via CocoaPods instead of our own install scripts.  
+  [David Jennes](https://github.com/djbe)
+  [#401](https://github.com/SwiftGen/SwiftGen/pull/401)
+* Enabled some extra SwiftLint rules for better code consistency.  
+  [David Jennes](https://github.com/djbe)
+  [#402](https://github.com/SwiftGen/SwiftGen/pull/402)
+  [#476](https://github.com/SwiftGen/SwiftGen/pull/476)
+* Updated to latest Xcode (10.0.0) and Swift 4.2.  
+  [David Jennes](https://github.com/djbe)
+  [#415](https://github.com/SwiftGen/SwiftGen/pull/415)
+  [#498](https://github.com/SwiftGen/SwiftGen/pull/498)
+* Update to Stencil 0.13.0, and use some of it's new filters in our templates.  
+  [David Jennes](https://github.com/djbe)
+  [#416](https://github.com/SwiftGen/SwiftGen/pull/416)
+  [#475](https://github.com/SwiftGen/SwiftGen/pull/475)
+  [#498](https://github.com/SwiftGen/SwiftGen/pull/498)
+* Store testing contexts as YAML files instead of PLISTs.  
+  [David Jennes](https://github.com/djbe)
+  [#418](https://github.com/SwiftGen/SwiftGen/pull/418)
+  [#461](https://github.com/SwiftGen/SwiftGen/pull/461)
+* Refactor the parsers as they're getting more complex.  
+  [David Jennes](https://github.com/djbe)
+  [#417](https://github.com/SwiftGen/SwiftGen/pull/417)
+  [#422](https://github.com/SwiftGen/SwiftGen/pull/422)
+* Disabled a SwiftLint rule for function parameter count.  
+  [Oleg Gorbatchev](https://github.com/gorbat-o)
+  [#428](https://github.com/SwiftGen/SwiftGen/pull/428)
+* Fix missing link in the README.  
+  [Takeshi Fujiki](https://github.com/takecian)
+  [#459](https://github.com/SwiftGen/SwiftGen/issues/459)
+
+## 5.3.0
+
+### Changes in core dependencies of SwiftGen
+
+* [StencilSwiftKit 2.4.0](https://github.com/SwiftGen/StencilSwiftKit/blob/2.4.0/CHANGELOG.md)
+* [Stencil 0.10.1](https://github.com/kylef/Stencil/blob/0.10.1/CHANGELOG.md)
+
+### New Features
+
+* XCAssets: exposed getter for image name string.  
+  [Abbey Jackson](https://github.com/abbeyjackson)
+  [SwiftGen/templates#85](https://github.com/SwiftGen/templates/pull/85)
+* XCAssets: exposed getter for color name string.  
+  [Stephan Diederich](https://github.com/diederich)
+  [SwiftGen/templates#87](https://github.com/SwiftGen/templates/pull/87)
+* Allows to set all properties as `public` by using `--param publicAccess` on all templates.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [SwiftGen/templates#84](https://github.com/SwiftGen/templates/pull/84)
+  [Txai Wieser](https://github.com/txaiwieser)
+  [SwiftGen/templates#81](https://github.com/SwiftGen/templates/pull/81)
+
+### Internal Changes
+
+* Merged the `SwiftGenKit` and `templates` repositories back into this repository for easier development and maintenance.  
+  [David Jennes](https://github.com/djbe)
+  [#356](https://github.com/SwiftGen/SwiftGen/pull/356)
+
+## 5.2.1
+
+### Bug Fixes
+
+* Fix SwiftGen no longer working using CLI parameters (instead of config file).  
+  [David Jennes](https://github.com/djbe)
+  [#347](https://github.com/SwiftGen/SwiftGen/pull/347)
+* Errors now properly exit with a non-zero exit code.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#348](https://github.com/SwiftGen/SwiftGen/pull/348)
+* `swiftgen --help` prints the full help back again
+  (and not just the help of the default `config run` subcommand).  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#349](https://github.com/SwiftGen/SwiftGen/pull/349)
+
+## 5.2.0
+
+### Changes in core dependencies of SwiftGen
+
+* [SwiftGenKit 2.1.1](https://github.com/SwiftGen/SwiftGenKit/blob/2.1.1/CHANGELOG.md)
+* [StencilSwiftKit 2.3.0](https://github.com/SwiftGen/StencilSwiftKit/blob/2.3.0/CHANGELOG.md)
+* [templates 2.2.0](https://github.com/SwiftGen/templates/blob/2.2.0/CHANGELOG.md)
+
+### New Features
+
+* You can now use a `swiftgen.yml` file to configure SwiftGen! 🎉  
+  Read more about it [in the dedicated documentation](Documentation/ConfigFile.md).  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#337](https://github.com/SwiftGen/SwiftGen/pull/337)
+* Storyboards: Added a new `ignoreTargetModule` parameter if you're using storyboards in multiple targets, to avoid issues with the generated code.  
+  [Julien Quéré](https://github.com/juli1quere)
+  [SwiftGen/templates#36](https://github.com/SwiftGen/templates/pull/36)
+
+### Bug Fixes
+
+* Fixes an issue in High Sierra where the output of the processed Catalog Entries was not ordered alphabetically.  
+  [Yusuke Kuroiwa](https://github.com/wakinchan)
+  [Francisco Diaz](https://github.com/fdiaz)
+  [SwiftGen/SwiftGenKit#57](https://github.com/SwiftGen/SwiftGenKit/pull/57)
+* Fonts: fix code which checks if a font is already registered.  
+  [Vladimir Burdukov](https://github.com/chipp)
+  [SwiftGen/templates#77](https://github.com/SwiftGen/templates/pull/77)
+* SwiftLint rules: Disabled the `superfluous_disable_command` rule
+  for all `swiftlint:disable` exceptions in all templates.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [SwiftGen/SwiftGen#334](https://github.com/SwiftGen/SwiftGen/issues/334)
+  [SwiftGen/templates#83](https://github.com/SwiftGen/templates/pull/83)
+* When installing SwiftGen via CocoaPods, the unneeded `file.zip` is not kept in `Pods/SwiftGen/` anymore _(freeing ~5MB on each install of SwiftGen made via CocoaPods!)_.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#342](https://github.com/SwiftGen/SwiftGen/pull/342)
+
+## 5.1.2
+
+### Internal Changes
+
+* Allows the SwiftGen source code to be built with Xcode 9.
+  This also has the nice side-effect of making the homebrew installation of SwiftGen also available for macOS 10.13.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [David Jennes](https://github.com/djbe)
+  [#330](https://github.com/SwiftGen/SwiftGen/issues/330)
+  [SwiftGen/Eve#10](https://github.com/SwiftGen/Eve/pull/10)
+
+## 5.1.1
+
+### Changes in core dependencies of SwiftGen
+
+* [templates 2.1.1](https://github.com/SwiftGen/templates/blob/2.1.1/CHANGELOG.md)
+
+### Bug Fixes
+
+* XCAssets: fixed some compatibility issues with the swift 3 template on Xcode 8, and with other templates.  
+  [David Jennes](https://github.com/djbe)
+  [SwiftGen/templates#76](https://github.com/SwiftGen/templates/pull/76)
+
+## 5.1.0
+
+### Changes in core dependencies of SwiftGen
+
+* [SwiftGenKit 2.1.0](https://github.com/SwiftGen/SwiftGenKit/blob/2.1.0/CHANGELOG.md)
+* [StencilSwiftKit 2.1.0](https://github.com/SwiftGen/StencilSwiftKit/blob/2.1.0/CHANGELOG.md)
+* [templates 2.1.0](https://github.com/SwiftGen/templates/blob/2.1.0/CHANGELOG.md)
+
+### New Features
+
+* Added Swift 4 templates. Use `-t swift4` or whatever variant you want to use
+  (see `swiftgen templates list` for the available names).  
+  [David Jennes](https://github.com/djbe)
+  [SwiftGen/templates/#67](https://github.com/SwiftGen/templates/pull/67)
+* XCAssets: Added support for named colors. When using `swiftgen xcassets` the bundled templates
+  will now also include colors found in the Asset Catalog in addition to the images.  
+  [David Jennes](https://github.com/djbe)
+  [SwiftGen/templates/#68](https://github.com/SwiftGen/templates/pull/68)
+* Fonts: the path to fonts will now default to just the font filename, but you can disable
+  this behaviour by enabling the `preservePath` parameter.  
+  [David Jennes](https://github.com/djbe)
+  [SwiftGen/templates/#71](https://github.com/SwiftGen/templates/pull/71)
+* Colors: new template that uses `#colorLiteral`s.  
+  Use `swiftgen colors -t literals-swift3` / `swiftgen colors -t literals-swift4` to use them.  
+  [David Jennes](https://github.com/djbe)
+  [SwiftGen/templates/#72](https://github.com/SwiftGen/templates/pull/72)
+
+## 5.0.0
+
+⚠️ This major version is a big milestone in which a lot of refactoring and cleaning has been done. Many features added over previous releases have been reworked and unified, while also preparing SwiftGen for future additions. This means that you'll need to adapt your command line invocations and custom templates to work with this new major version.
+
+Read the [SwiftGen 5.0 Migration Guide](Documentation/MigrationGuide.md#migrating-to-swiftgen-50) for a list of changes you'll need to apply.
+
+### Changes in core dependencies of SwiftGen
+
+* [SwiftGenKit 2.0.0](https://github.com/SwiftGen/SwiftGenKit/blob/2.0.0/CHANGELOG.md)
+* [StencilSwiftKit 2.0.0](https://github.com/SwiftGen/StencilSwiftKit/blob/2.0.0/CHANGELOG.md)
+* [Stencil 0.9.0](https://github.com/kylef/Stencil/blob/0.9.0/CHANGELOG.md)
+* [templates 2.0.0](https://github.com/SwiftGen/templates/blob/2.0.0/CHANGELOG.md)
+
+### Breaking Changes
+
+* Removed deprecated CLI options. Please consult the migration guide should you still use them.  
+  [David Jennes](https://github.com/djbe)
+  [#301](https://github.com/SwiftGen/SwiftGen/issues/301)
+* Disable default value for named template option and ensure that there is a template option.  
+  [Liquidsoul](https://github.com/liquidsoul)
+  [#283](https://github.com/SwiftGen/SwiftGen/issues/283)
+* Templates are now grouped by parser on the filesystem. This is only important if you had custom templates in the `Application Support` directory. To migrate your templates, place them in a subfolder with the name of the parser, and remove the prefix of the template filename.  
+  [David Jennes](https://github.com/djbe)
+  [#304](https://github.com/SwiftGen/SwiftGen/issues/304)
+* The `images` command has been renamed to `xcassets` to better reflect its functionality.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#317](https://github.com/SwiftGen/SwiftGen/issues/317)
+
+#### Notable breaking changes from other SwiftGen repositories
+
+* Many deprecated templates have been removed (or merged), and others have been renamed to reflect new behaviours. Please check the [templates migration guide](Documentation/templates/MigrationGuide.md#deprecated-templates-in-20-swiftgen-50) for more information.  
+  [David Jennes](https://github.com/djbe)
+  [SwiftGen/templates#47](https://github.com/SwiftGen/templates/issues/47)
+* There have been some breaking changes in the generated code for storyboards. Please check the [templates migration guide](Documentation/templates/MigrationGuide.md#deprecated-templates-in-20-swiftgen-50) for more information, where we also provide a compatibility template.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [SwiftGen/templates#65](https://github.com/SwiftGen/templates/issues/65)
+* Removed deprecated template context variables, and restructured many others. Please check the [SwiftGenKit migration guide](Documentation/SwiftGenKit%20Contexts/MigrationGuide.md#swiftgenkit-20-swiftgen-50-migration-guide) for more information.  
+  [David Jennes](https://github.com/djbe)
+  [SwiftGen/SwiftGenKit#5](https://github.com/SwiftGen/SwiftGenKit/issues/5)
+* Some filters have been removed in favour of Stencil's built in versions, and other filters have been updated to accept parameters. Please consult the [StencilSwiftKit migration guide](https://github.com/SwiftGen/StencilSwiftKit/blob/stable/Documentation/MigrationGuide.md#stencilswiftkit-20-swiftgen-50) for more information.  
+  [David Jennes](https://github.com/djbe)
+  [SwiftGen/StencilSwiftKit#5](https://github.com/SwiftGen/StencilSwiftKit/issues/5)
+  [SwiftGen/StencilSwiftKit#6](https://github.com/SwiftGen/StencilSwiftKit/issues/6)
+
+### New Features
+
+* Colors and strings commands now accept multiple input files. With these 2 additions, all swiftgen generator commands are able to handle multiple input files.  
+  [David Jennes](https://github.com/djbe)
+  [#313](https://github.com/SwiftGen/SwiftGen/issues/313)
+  [SwiftGen/SwiftGenKit#40](https://github.com/SwiftGen/SwiftGenKit/issues/40)
+  [SwiftGen/SwiftGenKit#41](https://github.com/SwiftGen/SwiftGenKit/issues/41)
+
+### Internal Changes
+
+* Improved installation instructions in the README.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#303](https://github.com/SwiftGen/SwiftGen/issues/303)
+
+#### Notable internal changes from other SwiftGen repositories
+
+* Switch back from `actool` to an internal parser to fix numerous issues with the former. This fixes issues a few people encountered when using asset catalogs that contained some of the less common set types.  
+  [David Jennes](https://github.com/djbe)
+  [#228](https://github.com/SwiftGen/SwiftGen/issues/228)
+  [SwiftGen/SwiftGenKit#43](https://github.com/SwiftGen/SwiftGenKit/issues/43)
+
+## 4.2.1
+
+### Changes in core dependencies of SwiftGen
+
+* [SwiftGenKit 1.1.0](https://github.com/SwiftGen/SwiftGenKit/blob/1.1.0/CHANGELOG.md)
+* [StencilSwiftKit 1.0.2](https://github.com/SwiftGen/StencilSwiftKit/blob/1.0.2/CHANGELOG.md)
+* [Stencil 0.9.0](https://github.com/kylef/Stencil/blob/0.9.0/CHANGELOG.md)
+* [templates 1.1.0](https://github.com/SwiftGen/templates/blob/1.1.0/CHANGELOG.md)
+
+### Bug Fixes
+
+* Fix a bug in which the version of SwiftGen was reported as `v0.0` by `swiftgen --version`.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+
+### Internal Changes
+
+* Update StencilGenKit to 1.0.2 and update Circle CI to Xcode 8.3.  
+  [Diogo Tridapalli](https://github.com/diogot)
+  [#295](https://github.com/SwiftGen/SwiftGen/issues/295)
+* Switch from Travis CI to Circle CI, clean up the Rakefile in the process.  
+  [David Jennes](https://github.com/djbe)
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#269](https://github.com/SwiftGen/SwiftGen/pull/269)
+* Fix remaining enum names not Swift 3 compliant.  
+  [Liquidsoul](https://github.com/liquidsoul)
+  [#297](https://github.com/SwiftGen/SwiftGen/issues/297)
+* Added the `CONTRIBUTING.md` file to help new contributors.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [Cihat Gündüz](https://github.com/Dschee)
+  [#149](https://github.com/SwiftGen/SwiftGen/pull/149)
+  [#298](https://github.com/SwiftGen/SwiftGen/pull/298)
+
+## 4.2.0
+
+### Changes in core dependencies of SwiftGen
+
+* [SwiftGenKit 1.0.1](https://github.com/SwiftGen/SwiftGenKit/blob/1.0.1/CHANGELOG.md)
+* [StencilSwiftKit 1.0.0](https://github.com/SwiftGen/StencilSwiftKit/blob/1.0.0/CHANGELOG.md)
+* [Stencil 0.8.0](https://github.com/kylef/Stencil/blob/0.8.0/CHANGELOG.md)
+* [templates 1.0.0](https://github.com/SwiftGen/templates/blob/1.0.0/CHANGELOG.md)
+
+### New Features
+
+* You can now pass custom parameters to your templates using the `--param X=Y` syntax.  
+  [@djbe](https://github.com/djbe)
+  [#265](https://github.com/SwiftGen/SwiftGen/pull/265/commits/3a7971ccbf16c41f0b2341e71b8a1ffbcabebecf)
+  * This command-line option can be repeated at will and used to pass structured custom parameters (e.g. `--param tabs=2 --param foo.bar=1 --param foo.baz=2`).  
+  * You can then use them in your templates using e.g. `{{param.tabs}}`, `{{param.foo.bar}}` & `{{param.foo.baz}}`.  
+* Templates can now access environment variables via the `env` key of the Stencil context (e.g. `{{env.USER}}`, `{{env.LANG}}`).  
+  [@djbe](https://github.com/djbe)
+  [#265](https://github.com/SwiftGen/SwiftGen/pull/265/commits/3a7971ccbf16c41f0b2341e71b8a1ffbcabebecf)
+  * This is especially useful when integrating SwiftGen as a Script Build Phase in your Xcode project as you can then access Xcode Build Settings exposed as
+  environment variables by Xcode, e.g. `{{env.PRODUCT_MODULE_NAME}}`.  
+
+#### Notable new features from other SwiftGen repositories
+
+* Use an explicit bundle parameter to support frameworks for all templates.  
+  [@NachoSoto](https://github.com/NachoSoto)
+  [@djbe](https://github.com/djbe)
+  [#255](https://github.com/SwiftGen/SwiftGen/pull/255)
+  [SwiftGen/templates#17](https://github.com/SwiftGen/templates/pull/17)
+
+### Deprecations
+
+In preparation for an upcoming cleanup of SwiftGen to remove some legacy code as well as Stencil old variables, tags and filters, and change the default templates to Swift 3, **some things are being deprecated and will be removed in the next major version 5.0**.
+
+As a result, if you wrote custom templates, you should already prepare for the upcoming 5.0 by migrating your templates to use the new variables (already avaiable in SwiftGen 4.2 / SwiftGenKit 1.0).
+
+See [#244](https://github.com/SwiftGen/SwiftGen/issues/244) and [the Migration Guide](Documentation/MigrationGuide.md) for a list of deprecations and their replacements.
+
+### Bug Fixes
+
+#### Notable bug fixes from other SwiftGen repositories
+
+* Storyboards templates won't `import` your app module anymore,
+  removing that annoying warning.  
+  [@djbe](https://github.com/djbe)
+  [SwiftGen/templates#19](https://github.com/SwiftGen/templates/pull/19)
+
+### Internal changes
+
+* SwiftGen has migrated to [its own GitHub organization](https://github.com/SwiftGen/SwiftGen) 🎉.  
+* SwiftGen has been split in multiple repositories and separate modules.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [@djbe](https://github.com/djbe)
+  [#240](https://github.com/SwiftGen/SwiftGen/issues/240)
+  [#265](https://github.com/SwiftGen/SwiftGen/pull/265)
+  * The present [SwiftGen](https://github.com/SwiftGen/SwiftGen) is the CLI parsing. It is in charge of calling the frameworks, feeding them appropriate parameters according to the command line arguments.
+  * [SwiftGenKit](https://github.com/SwiftGen/SwiftGenKit) is the framework responsible for parsing your assets/resources and turning them into a structured representation compatible with `Stencil` templates.
+  * [StencilSwiftKit](https://github.com/SwiftGen/StencilSwiftKit) is a framework adding some extensions to the template engine [Stencil](https://github.com/kylef/Stencil) used by SwiftGen. It adds some tags and filters as well as convenience methods shared both by SwiftGen itself and by [Sourcery](https://github.com/krzysztofzablocki/Sourcery).
+  * The SwiftGen templates has been moved into [a dedicated templates repo](https://github.com/SwiftGen/templates) so they can evolve and be unit-tested separately of SwiftGen.
+
+Note: The next minor version will focus on bringing more documentation for all this new structure and improve ease of future contributions.
+
+## 4.1.0
+
+### New Features
+
+* Added a script reference to simplify and automate localization of existing non localized project.  
+  [HuguesBR](https://github.com/HuguesBR)
+* Added a `storyboards-osx-swift3` template.  
+  [Felix Lisczyk](https://github.com/FelixII)
+  [#225](https://github.com/SwiftGen/SwiftGen/pull/225)
+* Added a `strings-no-comments-swift3` template that does not include the
+  default translation of each key.  
+  [Loïs Di Qual](https://github.com/ldiqual)
+  [#222](https://github.com/SwiftGen/SwiftGen/issues/222)
+* Images: new dot-syntax template, use `dot-syntax-swift3` or `dot-syntax` (for
+  Swift 2.3).  
+  [David Jennes](https://github.com/djbe)
+  [#206](https://github.com/SwiftGen/SwiftGen/pull/206)
+* Reworked the "dot-syntax" and "structured" templates to use the new `macro`
+  and `call` tags, which greatly simplifies the templates, and also removes the
+  limitation of 5-level deep structures.  
+  [David Jennes](https://github.com/djbe)
+  [#237](https://github.com/SwiftGen/SwiftGen/pull/237)
+* Storyboards: automatically detect the correct modules that need to be
+  imported. The `--import` option has therefore been deprecated, as well as the
+  `extraImports` template variable. Instead use the the new `modules` variable,
+   which offers the same functionality.  
+  [David Jennes](https://github.com/djbe)
+  [#243](https://github.com/SwiftGen/SwiftGen/pull/243)
+* Support multiple input paths for some commands.  
+  [David Jennes](https://github.com/djbe)
+  [#213](https://github.com/SwiftGen/SwiftGen/pull/213)
+  * `fonts` accepts multiple input directories, all found fonts will be added
+    to the `families` template variable.
+  * `images` now supports multiple asset catalogs as input. Templates can now
+    use the `catalogs` variable to access each individual catalog.
+  * `storyboards` accepts multiple paths (to folders or `storyboard` files).
+    All found storyboards will be available in the `storyboards` template
+    variable.
+
+### Bug Fixes
+
+* Strings: fix issue with `dot-syntax-swift3` where function definitions were
+  not Swift 3 guidelines compliant.  
+  [David Jennes](https://github.com/djbe)
+  [#241](https://github.com/SwiftGen/SwiftGen/issues/241)
+  [#247](https://github.com/SwiftGen/SwiftGen/pull/247)
+* Snake cased keys with uppercase letters are correctly camel cased again.  
+  [Cihat Gündüz](https://github.com/Dschee)
+  [#226](https://github.com/SwiftGen/SwiftGen/issues/226)
+  [#233](https://github.com/SwiftGen/SwiftGen/pull/233)
+
+### Internal changes
+
+* Better error handling in the `colors` command.  
+  [David Jennes](https://github.com/djbe)
+  [#227](https://github.com/SwiftGen/SwiftGen/pull/227)
+* Stencil: added two new tags `macro` and `call`, see the
+  [documentation](https://github.com/SwiftGen/SwiftGen/blob/4.1.0/documentation/Templates.md). for in depth explanations on how
+  to use them.  
+  [David Jennes](https://github.com/djbe)
+  [#237](https://github.com/SwiftGen/SwiftGen/pull/237)
+* SwiftLint: Remove `switch_case_on_newline` warning for generated color file.  
+  [Mickael Titeca](https://github.com/MickaCapi)
+  [#239](https://github.com/SwiftGen/SwiftGen/pull/239)
+* Stencil: better string filter testing and fixed a small issue with
+  `lowerFirstWord`.  
+  [David Jennes](https://github.com/djbe)
+  [#245](https://github.com/SwiftGen/SwiftGen/pull/245)
+
+## 4.0.1
+
+### Bug Fixes
+
+* Escape newlines again in .strings file keys.  
+  [ChristopherRogers](https://github.com/ChristopherRogers)
+  [#208](https://github.com/SwiftGen/SwiftGen/pull/208)
+* Fix broken `import` option added in 4.0.0.  
+  [David Jennes](https://github.com/djbe)
+  [#214](https://github.com/SwiftGen/SwiftGen/pull/214)
+* Show an error when the provided path to the `images` command is not an asset
+  catalog.  
+  [David Jennes](https://github.com/djbe)
+  [#217](https://github.com/SwiftGen/SwiftGen/pull/217)
+* Strings dot-syntax template: use `enum`s for namespacing instead of `struct`s.  
+  [David Jennes](https://github.com/djbe)
+  [#218](https://github.com/SwiftGen/SwiftGen/pull/218)
+
+### Internal changes
+
+* Swift 3 migration.  
+  [ahtierney](https://github.com/ahtierney)
+  [#201](https://github.com/SwiftGen/SwiftGen/pull/201)
+* Restructure the SwiftGen project to build as an `.app` during
+  developement, for easier debugging in Xcode.  
+  [ahtierney](https://github.com/ahtierney)
+  [#204](https://github.com/SwiftGen/SwiftGen/pull/204)
+* Consolidate the use of PathKit internally.  
+  [David Jennes](https://github.com/djbe)
+  [#212](https://github.com/SwiftGen/SwiftGen/pull/212)
+* Updated Stencil to [0.7.2](https://github.com/kylef/Stencil/releases/tag/0.7.0).  
+  [Kyle Fuller](https://github.com/kylef)
+  [#216](https://github.com/SwiftGen/SwiftGen/issues/216)
+
+## 4.0.0
+
+### Breaking Changes
+
+* Change swift 3 storyboard segue template's sender from `AnyObject` to `Any`.  
+  [Derek Ostrander](https://github.com/dostrander)
+  [#197](https://github.com/SwiftGen/SwiftGen/pull/197)
+* Fix swift 3 storyboard templates to be compliant with swift 3 api design guidelines.  
+  [Afonso](https://github.com/afonsograca)
+  [#194](https://github.com/SwiftGen/SwiftGen/pull/194)
+* Remove the `key` param label from the `tr` function for Localized String in the Swift 3 template.  
+  [AndrewSB](https://github.com/AndrewSB)
+  [#190](https://github.com/SwiftGen/SwiftGen/pull/190)
+* The `swiftgen images` command now uses the `actool` utility to parse asset catalogs,
+  ensuring that the parser correctly handles namespaced folders.  
+  ⚠️ Note that you now have to specify the exact path to your `.xcassets` assets catalogs
+  when using `swiftgen images` (and not just a directory to parse).  
+  [David Jennes](https://github.com/djbe)
+  [#199](https://github.com/SwiftGen/SwiftGen/pull/199)
+
+### New Features
+
+* Add support for multiline strings in `*.strings` file.  
+  [Jeong Yonguk](https://github.com/alldne)
+  [#192](https://github.com/SwiftGen/SwiftGen/pull/192)
+* Add option to add import statements at the top of the generated swift file (for
+  storyboards) using the `import` flag.  
+  [David Jennes](https://github.com/djbe)
+  [#175](https://github.com/SwiftGen/SwiftGen/pull/175)
+* Escape reserved swift keywords in the structured and dot-syntax generated strings code.  
+  [Afonso](https://github.com/afonsograca)
+  [#198](https://github.com/SwiftGen/SwiftGen/pull/198)
+
+## 3.0.1
+
+* Add support for Xcode 8 and Swift 2.3.  
+  _(Should still compile in Xcode 7.3 but the `Rakefile` to build, install and release requires Xcode 8)_.  
+  [Valentin Knabel](https://github.com/vknabel)
+  [Ignacio Romero Zurbuchen](https://github.com/dzenbot)
+  [HanxuanZhou](https://github.com/GenoZhou)
+  [Syo Ikeda](https://github.com/ikesyo)
+
+
+## 3.0.0
+
+* Add template that calls `NSLocalizedString()` separately for each string,
+  which is useful when trying to extract strings in the app to a `.strings` file.  
+  [Ahmet Karalar](https://github.com/akaralar)
+* Add some `file_length` and similar SwiftLint exceptions in bundled templates, as
+  files generated by SwiftGen might contain lots of constants and can be long by design.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+* Error messages ("template not found", etc) are now printed on `stderr`.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+* Add more `swiftgen templates` subcommands.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  * `swiftgen templates list` lists all the available templates
+  * `swiftgen templates which <name>` prints the path to the template named `<name>`
+  * `swiftgen templates cat <name>` prints the content to the template named `<name>`
+  * `<name>` here can be either a parser name like `colors` or a
+    composed name `colors-rawValue` for a specific template.
+* Fix swift 3 renaming change in strings-swift3.stencil.  
+  [Kilian Koeltzsch](https://github.com/kiliankoe)
+  [#150](https://github.com/SwiftGen/SwiftGen/pull/150)
+* Fix non-custom class, non-base view controller handling in storyboards-swift3.stencil.  
+  [Syo Ikeda](https://github.com/ikesyo)
+  [#152](https://github.com/SwiftGen/SwiftGen/pull/152)
+* Add strongly typed `initialViewController()` overrides for storyboard templates if available.  
+  [Syo Ikeda](https://github.com/ikesyo)
+  [#153](https://github.com/SwiftGen/SwiftGen/pull/153)
+  [#163](https://github.com/SwiftGen/SwiftGen/pull/163)
+* Add support for font files containing multiple descriptors.  
+  [Chris Ellsworth](https://github.com/chrisellsworth)
+  [#156](https://github.com/SwiftGen/SwiftGen/pull/156)
+* Update deprecated usage of generics for Swift 3 / Xcode 8 beta 6.  
+  [Chris Ellsworth](https://github.com/chrisellsworth)
+  [#158](https://github.com/SwiftGen/SwiftGen/pull/158)
+* Fix case when missing positional parameters, which leads to parameters in the enum with
+  unspecified type (undeterminable from the `Localizable.strings` format analysis) where
+  reported as `Any` — which is not a `CVarArgType`. Now using `UnsafePointer<()>`
+  arguments instead for such odd edge-cases that should never happen anyway.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+* Now reports an error when it failed to parse a color in a color input file.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#162](https://github.com/SwiftGen/SwiftGen/issues/162)
+* New Strings template (available via `-t dot-syntax`), allowing string keys containing dots (like foo.bar.baz) to be organized as a hierarchy and accessible via dot syntax.  
+  [Cihat Gündüz](https://github.com/Dschee)
+  [#159](https://github.com/SwiftGen/SwiftGen/pull/159)
+* Update Swift 3 templates to use lowercase enums.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#166](https://github.com/SwiftGen/SwiftGen/pull/166)
+* New Strings template (available via `-t dot-syntax-swift3`), allowing keys with dots in Swift 3 (see above).  
+  [Cihat Gündüz](https://github.com/Dschee)
+  [#168](https://github.com/SwiftGen/SwiftGen/pull/168)
+
+> 💡 You can now **create your custom templates more easier than ever**, by cloning an existing template!
+>
+> e.g. to clone [the default `strings-default.stencil` template](https://github.com/SwiftGen/SwiftGen/blob/3.0.0/templates/strings-default.stencil):
+>
+> * use `swiftgen templates cat strings --output strings-custom.stencil`
+> * modify the cloned `strings-custom.stencil` template to your liking
+> * use it with `swiftgen strings … --templatePath strings-custom.stencil …` in your projects!
+
+### Important Notes
+
+- Some keys for various templates have changed to provide more flexibility and enable some new features in the templates. As a result, **if you created your own custom templates, they might not all be totally compatible with SwiftGen 3.0.0** (hence the new major version).
+Please read the [Custom Templates documentation](https://github.com/SwiftGen/SwiftGen/blob/4.1.0/documentation/Templates.md) to find out the new Stencil context keys and update your custom templates accordingly.
+
+_If you're using one of the bundled templates, all of them have been updated appropriately._
+
+- Also **if you use Swift 3**, and thus use the `-t swift3` flag to use the Swift 3 templates, be advised those has been modified to take the latest Swift 3 modifications into account (including naming convensions) so your code might need to be updated according to match the latest Swift 3 recommendations.
+
+## 2.0.0
+
+* Fix issue with txt files bailing on comments.  
+  [Derek Ostrander](https://github.com/dostrander)
+  [#140](https://github.com/SwiftGen/SwiftGen/issues/140)
+* Added support for tvOS and watchOS in images, fonts and color templates.  
+  [Tom Baranes](https://github.com/tbaranes)
+  [#145](https://github.com/SwiftGen/SwiftGen/pull/145)
+* Added enum-based structured identifiers via `-t structured` option.  
+  [Cihat Gündüz](https://github.com/Dschee)
+  [#148](https://github.com/SwiftGen/SwiftGen/pull/148)  
+* Added support for OSX in storyboards.  
+  [Tom Baranes](https://github.com/tbaranes)
+  [#131](https://github.com/SwiftGen/SwiftGen/pull/131)
+
+Note: The `Stencil` context keys (the name of the variables used in templates) for storyboard has changed a bit.
+Especially, `class` has been renamed into `customClass` (see [#131](https://github.com/SwiftGen/SwiftGen/pull/131))
+to better describe the intent (as this isn't defined if there is no _custom_ class set in the Storyboard), and
+new keys `isBaseViewController` and `baseType` has been added.
+
+This means that if you did implement your own custom templates for storyboards (instead of using the bundled ones),
+you'll have to remplace `{{class}}` by `{{customClass}}` in those storyboard templates, otherwise they'll probably
+stop working as expected. That's the main reason why the version has been bumped to a major version 2.0.0.
+
+
+## 1.1.2
+
+* Fix issue introduced by 1.1.1 in storyboard templates not returning.  
+  [Ben Chatelain](https://github.com/phatblat)
+  [#138](https://github.com/SwiftGen/SwiftGen/pull/138)
+
+## 1.1.1
+
+* Removed the last force-unwrap from storyboard templates.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+
+## 1.1.0
+
+* Added step to ensure all templates are [Swiftlint](https://github.com/realm/SwiftLint)'ed
+  and don't violate any code style rule.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [AJ9](https://github.com/AJ9)
+  [#80](https://github.com/SwiftGen/SwiftGen/pull/80)
+* Added support for OSX in images, fonts and color templates.  
+  [Tom Baranes](https://github.com/tbaranes)
+  [#125](https://github.com/SwiftGen/SwiftGen/pull/125)
+  [#126](https://github.com/SwiftGen/SwiftGen/pull/126)
+  [#127](https://github.com/SwiftGen/SwiftGen/pull/127)
+* Added missing FontConvertible protocol conformance to default fonts template.  
+  [Ben Chatelain](https://github.com/phatblat)
+  [#129](https://github.com/SwiftGen/SwiftGen/pull/129)
+
+## 1.0.0
+
+* Restructured colors & fonts templates to workaround the same LLVM issue as #112 with nested types
+  inside existing UIKit classes in Release/Optimized builds.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+* Added support for Fonts using the `swiftgen fonts` command.  
+  [Derek Ostrander](https://github.com/dostrander)
+  [#102](https://github.com/SwiftGen/SwiftGen/pull/102)
+* Added support for TXT (`colors.txt`) files to have named value.  
+  [Derek Ostrander](https://github.com/dostrander)
+  [#118](https://github.com/SwiftGen/SwiftGen/pull/118)
+* Restructured image templates to work around an LLVM issue with nested types.  
+  [Ken Grigsby](https://github.com/kgrigsby59)
+  [#112](https://github.com/SwiftGen/SwiftGen/issues/112)
+* Added Swift 3 templates for storyboards and strings.  
+  [Andrew Breckenridge](https://github.com/AndrewSB)
+  [#117](https://github.com/SwiftGen/SwiftGen/pull/117)
+
+## 0.8.0
+
+* Introducing alternative way to install SwiftGen: using CocoaPods! See README for more details.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#95](https://github.com/SwiftGen/SwiftGen/issues/95)
+* Added support for JSON (`colors.json`) files as input for the `swiftgen colors` subcommand.  
+  [Derek Ostrander](https://github.com/dostrander)
+* Use `String(format:locale:arguments:)` and the `NSLocale.currentLocale()` in the "string" templates so that it works with `.stringdict` files and pluralization.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#91](https://github.com/SwiftGen/SwiftGen/issues/91)
+* Add support for Android `colors.xml` files as input for the `swiftgen colors` subcommand.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#15](https://github.com/SwiftGen/SwiftGen/issues/15)
+* Removed the useless `import Foundation` from the "images" templates.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+* Added computed property `var color: UIColor` to the color templates.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+
+
+## 0.7.6
+
+#### Enhancements
+
+* Fixed build loop by changing SwiftGen to only write to the output file if the generated code is different from the file contents.  
+  [Mathias Nagler](https://github.com/mathiasnagler)
+  [#90](https://github.com/SwiftGen/SwiftGen/pull/90)
+
+#### Fixes
+
+* Fixed typos in code and descriptions: _instanciate_ -> _instantiate_. Please note that the default template used for storyboards `storyboards-default.stencil` had to be modified, so make sure to update your codebase accordingly.  
+  [Pan Kolega](https://github.com/pankolega)
+  [#83](https://github.com/SwiftGen/SwiftGen/pull/83)
+* Fixed issue in `Rakefile` when trying to install via `rake` in a path containing `~`.  
+  [Jesse Armand](https://github.com/jessearmand)
+  [#88](https://github.com/SwiftGen/SwiftGen/pull/88)
+
+## 0.7.5
+
+#### Enhancements
+
+* Updated stencils and unit tests to pass [SwiftLint](https://github.com/realm/SwiftLint).  
+  [Adam Gask](https://github.com/AJ9)
+  [#79](https://github.com/SwiftGen/SwiftGen/pull/79)
+* Updated `storyboards-default.stencil` to better avoid name confusions.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+   * Now `cases` names are suffixed with `…Scene` and `static func` are prefixed with `instantiate…` to lower the risks of a name conflict with your ViewController classes.
+   * The old template is still available but has been renamed `storyboards-uppercase.stencil`
+* Added support for `*.clr` files (files to store `NSColorList`'s presented in Color Picker on "Color Palettes" tab).  
+  [Ilya Puchka](https://github.com/ilyapuchka)
+  [#81](https://github.com/SwiftGen/SwiftGen/pull/81)
+
+## 0.7.4
+
+#### Enhancements
+
+* Added View Controller Placeholders support.  
+  [Viacheslav Karamov](https://github.com/vkaramov/)
+  [#61](https://github.com/SwiftGen/SwiftGen/issues/61)
+
+## 0.7.3
+
+#### Fixes
+
+* Restructured storyboard templates to work around an LLVM issue with nested types.  
+  [Ryan Booker](https://github.com/ryanbooker)
+  [#57](https://github.com/SwiftGen/SwiftGen/issues/57#issuecomment-159996671)
+
+> Scenes and Segues are now referenced via `StoryboardScene.<Storyboard>` and `StoryboardSegue.<Storyboard>.<Segue>`
+
+## 0.7.2
+
+#### Enhancements
+
+* Adding comments to generated color enums which allow you to see the color in the QuickHelp documentation.  
+
+* The default translation of strings are now added as documentation comments to the enum cases.  
+  _You can add translations to your own templates by using the `string.translation` variable_.  
+  [@MrAlek](https://github.com/MrAlek)
+  [#58](https://github.com/SwiftGen/SwiftGen/issues/58)
+  [#60](https://github.com/SwiftGen/SwiftGen/pull/60)
+
+#### Fixes
+
+* Fix an issue with the colors template due to an Apple Bug when building in Release and with WMO enabled.  
+  [#56](https://github.com/SwiftGen/SwiftGen/issues/56)
+
+## 0.7.1
+
+#### Fixes
+
+* Fix issue with `swiftgen strings` that were using the colors templates instead of the strings template by default.  
+  [@ChristopherRogers](https://github.com/ChristopherRogers)
+  [#54](https://github.com/SwiftGen/SwiftGen/pull/54)
+
+## 0.7.0
+
+#### Enhancements
+
+* Allow using **custom templates by name**.  
+  [#42](https://github.com/SwiftGen/SwiftGen/issues/42)
+  [#50](https://github.com/SwiftGen/SwiftGen/pull/50)
+  * Now the `-t` flag expect a template name (defaults to `default`), and will search a matching template in `Application Support` first, then in the templates bundled with SwiftGen.  
+  * You can still specify a template by path using `-p`.  
+  * For more info, see [this dedicated documentation](https://github.com/SwiftGen/SwiftGen/blob/4.1.0/documentation/Templates.md).  
+* You can now list all templates available (both bundled templates and custom ones) using the `swiftgen templates` command.  
+  [#42](https://github.com/SwiftGen/SwiftGen/issues/42)
+  [#50](https://github.com/SwiftGen/SwiftGen/pull/50)
+* Add a `performSegue(_:sender:)` extension on `UIViewController` to accept a `StoryboardSegue` as parameter.  
+  You can now for example call `vc.performSegue(UIStoryboard.Segue.Wizard.ShowPassword)`.  
+  [#37](https://github.com/SwiftGen/SwiftGen/issues/37)
+
+SwiftGen now comes bundled with some alternate templates, especially `colors-rawValue`, `images-allvalues` and `storyboards-lowercase`, in addition to the default templates.
+
+#### Fixes
+
+* Now `swiftgen storyboards` doesn't generate duplicate enum cases for identical segues (those having equal identifiers and shared custom class).  
+  [@filwag](https://github.com/filwag)
+  [#43](https://github.com/SwiftGen/SwiftGen/pull/43)
+* Fix compilation issue for storyboards without any scene.  
+  [Viacheslav Karamov](https://github.com/vkaramov/)
+  [#47](https://github.com/SwiftGen/SwiftGen/issues/47)
+* Propose an alternate template using lowercase names, especially for when storyboard identifiers match view controller class names.  
+  [Viacheslav Karamov](https://github.com/vkaramov/)
+  [#48](https://github.com/SwiftGen/SwiftGen/issues/48)
+* Introduced an `image-allvalues` template that exposes the list of all images in a `static let allValues` array.  
+  [Ahmed Mseddi](https://github.com/amseddi)
+  & Guillaume Lagorce
+  [#44](https://github.com/SwiftGen/SwiftGen/pull/44)
+* Fix issue with Storyboards without any StoryboardID (all scenes being anonymous) not extending `StoryboardScene`.  
+  [#36](https://github.com/SwiftGen/SwiftGen/issues/36)
+
+## 0.6.0
+
+### New Features: Templates
+
+* `SwiftGen` now uses [Stencil](https://github.com/kylef/Stencil) template engine to produce the generated code.
+* This means that the generate code will be easier to improve.
+* This also means that **you can use your own templates** to generate code that better suits your needs and preferences, using `swiftgen … --template FILE …`.
+
+### Fixes
+
+* The correct type of _ViewController_ (`UIViewController`, `UINavigationController`, `UITableViewController`, …) is now correctly generated even if not a custom subclass.  
+  [#40](https://github.com/SwiftGen/SwiftGen/issues/40)
+* Fix issue with `.strings` files encoded in UTF8.  
+  [#21](https://github.com/SwiftGen/SwiftGen/issues/21)
+
+## 0.5.2
+
+### New Features
+
+* It's now possible to specify which chars should not be used when generating `case` identifiers.  
+  [@Igor-Palaguta](https://github.com/Igor-Palaguta)
+  [#34](https://github.com/SwiftGen/SwiftGen/pull/34)
+
+## 0.5.1
+
+#### Fixes
+
+* Installing via `rake install` or `brew install` will now copy the Swift dylibs too, so that `swiftgen` installation won't depend on the location of your Xcode.app (so it'll work on every machine even if you rename your Xcode).
+* Fixed links in Playground and Licence headers in source code.
+
+## 0.5.0
+
+#### New Features
+
+* Migrating to [Commander](https://github.com/kylef/Commander) to parse the CLI arguments.  
+  [23](https://github.com/SwiftGen/SwiftGen/issues/23)
+  [#30](https://github.com/SwiftGen/SwiftGen/issues/30)
+* `swiftgen` is now a single binary, and the subcommand names have changed to be more consistent.  
+  [#30](https://github.com/SwiftGen/SwiftGen/issues/30)
+* New `--output` option.  
+  [#30](https://github.com/SwiftGen/SwiftGen/issues/30)
+
+> You must now use the subcommands `swiftgen images`, `swiftgen strings`, `swiftgen storyboards` and `swiftgen colors`. See `swiftgen --help` for more usage info.
+
+#### Fixes
+
+* Fix color parsing with absent alpha.  
+  [@Igor-Palaguta](https://github.com/Igor-Palaguta)
+  [#28](https://github.com/SwiftGen/SwiftGen/pull/28)
+
+## 0.4.4
+
+* Updated Unit tests for latest Swift 2.0 & tested against Xcode 7.1
+* Fix small typos in code
+* Guard against empty `enums`  
+
+## 0.4.3
+
+* Updated for Xcode 7 Beta 6.  
+  [@Dimentar](https://github.com/Dimentar)
+  [#14](https://github.com/SwiftGen/SwiftGen/pull/14)
+
+## 0.4.2
+
+* Added `import Foundation` on top of `swiftgen-l10n` generated code.  
+  [@Nick11](https://github.com/Nick11)
+  [#12](https://github.com/SwiftGen/SwiftGen/pull/12)
+
+## 0.4.1
+
+* Updated for Xcode 7 Beta 5
+* `swiftgen-storyboard` now allows to take a path to a `.storyboard` file as argument (as an alternative to give a path to a whole directory)
+* The `-v` and `--version` flags are now recognized and print the executable version.
+
+## 0.4.0
+
+* Reorganized files into an **Xcode project** with one target per executable.  
+  [#2](https://github.com/SwiftGen/SwiftGen/issues/2)
+* Added **Unit Tests** (one per executable + one for common code).  
+  [#2](https://github.com/SwiftGen/SwiftGen/issues/2)
+* Improved `SwiftGen-L10n` parsing of format strings and placeholders.  
+  [#4](https://github.com/SwiftGen/SwiftGen/issues/4)
+  [#5](https://github.com/SwiftGen/SwiftGen/issues/5)
+  [#6](https://github.com/SwiftGen/SwiftGen/issues/6)
+* Updated `Rakefile` so that it now invokes `xcodebuild install`. You can now easily build & install all `swiftgen-xxx` executables in `/usr/local/bin` or anywhere else.
+* Added a **version** string (date + sha1) to the built executables (displayed when invoked with no argument)
+
+## 0.3.0
+
+* Reducted the default code generated by `SwiftGenColorEnumBuilder` to avoid clobbering the `UIColor` namespace
+* Changed the "namespacing `enum`" in `UIStoryboard` to a `struct` to avoid confusion with the inner enums
+* The `UIStoryboard.Scene` enums now use `static func` instead of `static var` for the dedicated `ViewController` constructors ^(†)
+
+^(†) _because it feels more explicit that calling a function like `UIStoryboard.Scene.Wizard.validatePasswordViewController()` will actually **instantiate** a new `ViewController`, rather than returning an existing one._
+
+## 0.2.0
+
+* Added `Segues` enums to `UIStoryboard` to be able to access their identifiers easily.  
+  [@esttorhe](https://github.com/esttorhe)
+  [#8](https://github.com/SwiftGen/SwiftGen/pull/8)
+* Added this very `CHANGELOG.md`
+
+## 0.1.0
+
+Considered to be the first cleaned-up version, far from finished but really usable with clean code.
+
+* Cleaner README
+* Namespace the generated `enums` in an outer `enum` to avoid clobbering the `UIStoryboard` namespace
+
+## 0.0.4
+
+* Introducing `SwiftGenColorEnumBuilder`
+* `swiftgen-colors` CLI
+* Added ability to choose indentation
+
+## 0.0.3
+
+* Introducing `SwiftGenL10nEnumBuilder`
+* `swiftgen-l10n` CLI
+* Started playing with `UIColor` enums in the playground
+
+## 0.0.2
+
+* Introducing `SwiftGenStoryboardEnumBuilder` class
+* `swiftgen-storyboard` CLI
+
+## 0.0.1
+
+Initial version:
+
+* Mostly testing stuff in a playground
+* Introducing `SwiftGenAssetsEnumBuilder` class
+* `swiftgen-assets` CLI

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/LICENCE
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/LICENCE
@@ -1,0 +1,21 @@
+MIT Licence
+
+Copyright (c) 2022 SwiftGen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/README.md
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/README.md
@@ -1,0 +1,974 @@
+# SwiftGen
+
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/SwiftGen.svg)](https://img.shields.io/cocoapods/v/SwiftGen.svg)
+[![Platform](https://img.shields.io/cocoapods/p/SwiftGen.svg?style=flat)](http://cocoadocs.org/docsets/SwiftGen)
+![Swift 4.x](https://img.shields.io/badge/Swift-4.x-orange) ![Swift 5.x](https://img.shields.io/badge/Swift-5.x-orange)
+
+SwiftGen is a tool to automatically generate Swift code for resources of your projects (like images, localised strings, etc), to make them type-safe to use.
+
+<table border="0"><tr>
+  <td>
+    <img alt="SwiftGen Logo" src="https://github.com/SwiftGen/Eve/raw/master/logo/logo-256.png" />
+  </td><td>
+    <ul>
+        <li><a href="#installation">Installation</a>
+        <li><a href="#configuration-file">Configuration File</a>
+        <li><a href="#choosing-your-template">Choosing your template</a>
+        <li><a href="#additional-documentation">Additional documentation</a>
+    </ul>
+    Then generate constants for:
+    <ul>
+      <li><a href="#asset-catalog">Assets Catalogs</a>
+      <li><a href="#colors">Colors</a>
+      <li><a href="#core-data">Core Data</a>
+      <li><a href="#files">Files</a>
+      <li><a href="#fonts">Fonts</a>
+      <li><a href="#interface-builder">Interface Builder files</a>
+      <li><a href="#json-and-yaml">JSON and YAML files</a>
+      <li><a href="#plists">Plists</a>
+      <li><a href="#strings">Localizable strings</a>
+    </ul>
+  </td>
+</tr></table>
+
+<span style="float:none" />
+
+There are multiple benefits in using this:
+
+* Avoid any risk of typo when using a String
+* Free auto-completion
+* Avoid the risk of using a non-existing asset name
+* All this will be ensured by the compiler and thus avoid the risk of crashing at runtime.
+
+Also, it's fully customizable thanks to Stencil templates, so even if it comes with predefined templates, you can make your own to generate whatever code fits your needs and your guidelines!
+
+## Installation
+
+There are multiple possibilities to install SwiftGen on your machine or in your project, depending on your preferences and needs:
+
+<details>
+<summary><strong>Download the ZIP</strong> for the latest release</summary>
+
+* [Go to the GitHub page for the latest release](https://github.com/SwiftGen/SwiftGen/releases/latest)
+* Download the `swiftgen-x.y.z.zip` file associated with that release
+* Extract the content of the zip archive in your project directory
+
+We recommend that you **unarchive the ZIP inside your project directory** and **commit its content** to git. This way, **all coworkers will use the same version of SwiftGen for this project**.
+
+If you unarchived the ZIP file in a folder e.g. called `swiftgen` at the root of your project directory, you can then invoke SwiftGen in your Script Build Phase using:
+
+```sh
+"${PROJECT_DIR}/swiftgen/bin/swiftgen" …
+```
+
+---
+</details>
+<details>
+<summary>Via <strong>CocoaPods</strong></summary>
+
+If you're using CocoaPods, simply add `pod 'SwiftGen', '~> 6.0'` to your `Podfile`.
+
+Then execute `pod install --repo-update` (or `pod update SwiftGen` if you want to update an existing SwiftGen installation) to download and install the `SwiftGen` binaries and dependencies in `Pods/SwiftGen/bin/swiftgen` next to your project.
+
+Given that you can specify an exact version for `SwiftGen` in your `Podfile`, this allows you to ensure **all coworkers will use the same version of SwiftGen for this project**.
+
+You can then invoke SwiftGen in your Script Build Phase using:
+
+```sh
+if [[ -f "${PODS_ROOT}/SwiftGen/bin/swiftgen" ]]; then
+  "${PODS_ROOT}/SwiftGen/bin/swiftgen" …
+else
+  echo "warning: SwiftGen is not installed. Run 'pod install --repo-update' to install it."
+fi
+```
+
+> Similarly, be sure to use `Pods/SwiftGen/bin/swiftgen` instead of just `swiftgen` where we mention commands with `swiftgen` in the rest of the documentation.
+
+_Note: SwiftGen isn't really a pod, as it's not a library your code will depend on at runtime; so the installation via CocoaPods is just a trick that installs the SwiftGen binaries in the Pods/ folder, but you won't see any swift files in the Pods/SwiftGen group in your Xcode's Pods.xcodeproj. That's normal; the SwiftGen binary is still present in that folder in the Finder._
+
+---
+</details>
+<details>
+<summary>Via <strong>Homebrew</strong> <em>(system-wide installation)</em></summary>
+
+To install SwiftGen via [Homebrew](http://brew.sh), simply use:
+
+```sh
+$ brew update
+$ brew install swiftgen
+```
+
+This will install SwiftGen **system-wide**. The same version of SwiftGen will be used for all projects on that machine, and you should make sure all your coworkers have the same version of SwiftGen installed on their machine too.
+
+You can then invoke `swiftgen` directly in your Script Build Phase (as it will be in your `$PATH` already):
+
+```sh
+swiftgen … 
+```
+
+---
+</details>
+<details>
+<summary>Via <strong>Mint</strong> <em>(system-wide installation)</em></summary>
+
+> ❗️SwiftGen 6.0 or higher only.
+
+To install SwiftGen via [Mint](https://github.com/yonaskolb/Mint), simply use:
+
+```sh
+$ mint install SwiftGen/SwiftGen
+```
+---
+</details>
+<details>
+<summary><strong>Compile from source</strong> <em>(only recommended if you need features from the `stable` branch or want to test a PR)</em></summary>
+
+This solution is when you want to build and install the latest version from `stable` and have access to features which might not have been released yet.
+
+* If you have `homebrew` installed, you can use the following command to build and install the latest commit:
+
+```sh
+brew install swiftgen --HEAD
+```
+
+* Alternatively, you can clone the repository and use `rake cli:install` to build the tool and install it from any branch, which could be useful to test SwiftGen in a fork or a Pull Request branch.
+
+Some Ruby tools are used in the build process, and the system Ruby works well if you are running a recent macOS.  However, if you are using `rbenv` you can run `rbenv install` to make sure you have a matching version of Ruby installed.  
+
+Then install the Ruby Gems:
+
+```sh
+# Install bundle if it isn't installed
+gem install bundle
+# Install the Ruby gems from Gemfile
+bundle install
+```
+
+You can now install to the default locations (no parameter) or to custom locations:
+
+```sh
+# Binary is installed in `./.build/swiftgen/bin`
+$ rake cli:install
+# - OR -
+# Binary will be installed in `~/swiftgen/bin``
+$ rake cli:install[~/swiftgen/bin]
+```
+
+You can then invoke SwiftGen using the path to the binary where you installed it:
+
+```sh
+~/swiftgen/bin/swiftgen …
+```
+
+Or add the path to the `bin` folder to your `$PATH` and invoke `swiftgen` directly.
+
+---
+</details>
+
+### Known Installation Issues On macOS Before 10.14.4
+
+Starting with [SwiftGen 6.2.1](https://github.com/SwiftGen/SwiftGen/releases/6.2.1), if you get an error similar to `dyld: Symbol not found: _$s11SubSequenceSlTl` when running SwiftGen, you'll need to install the [Swift 5 Runtime Support for Command Line Tools](https://support.apple.com/kb/DL1998).
+
+Alternatively, you can:
+
+- Update to macOS 10.14.4 or later
+- Install Xcode 10.2 or later at `/Applications/Xcode.app`
+- Rebuild SwiftGen from source using Xcode 10.2 or later
+
+## Configuration File
+
+> ❗️ If you're migrating from older SwiftGen versions, don't forget to [read the Migration Guide](Documentation/MigrationGuide.md).
+
+SwiftGen is provided as a single command-line tool which uses a configuration file to define the various parsers to run (depending on the type of input files you need to parse) and their parameters.
+
+To create a sample configuration file as a starting point to adapt to your needs, run `swiftgen config init`.
+
+Each parser described in the [configuration file](Documentation/ConfigFile.md) (`strings`, `fonts`, `ib`, …) typically corresponds to a type of input resources to parse (strings files, IB files, Font files, JSON files, …), allowing you to generate constants for each types of those input files.
+
+To use SwiftGen, simply create a `swiftgen.yml` YAML file (either manually or using `swiftgen config init`) then edit it to adapt to your project. The config file should list all the parsers to invoke, and for each parser, the list of inputs/outputs/templates/parameters to use for it.
+
+For example:
+
+```yaml
+strings:
+  inputs: Resources/Base.lproj
+  outputs:
+    - templateName: structured-swift5
+      output: Generated/Strings.swift
+xcassets:
+  inputs:
+    - Resources/Images.xcassets
+    - Resources/MoreImages.xcassets
+    - Resources/Colors.xcassets
+  outputs:
+    - templateName: swift5
+      output: Generated/Assets.swift
+```
+
+Then you just have to invoke `swiftgen config run`, or even just `swiftgen` for short, and it will execute what's described in the configuration file.
+
+[The dedicated documentation](Documentation/ConfigFile.md) explains the syntax and possibilities in details – like how to pass custom parameters to your templates, use `swiftgen config lint` to validate your config file, how to use alternate config files, and other tips.
+
+There are also additional subcommands you can invoke from the command line to manage and configure SwiftGen:
+
+* The `swiftgen config` subcommand to help you with the configuration file, especially `swiftgen config init` to create a starting point for your config and `swiftgen config lint` to validate that your Config file is valid and has no errors
+* The `swiftgen template` subcommands to help you print, duplicate, find and manage templates bundled with SwiftGen
+
+Lastly, you can use `--help` on `swiftgen` or one of its subcommand to see the detailed usage.
+
+<details>
+<summary><strong>Directly invoking a parser without a config file</strong></summary>
+
+While we highly recommend the use a configuration file for performance reasons (especially if you have multiple outputs, but also because it's more flexible), it's also possible to directly invoke the available parsers individually using `swiftgen run`:
+
+* `swiftgen run colors [OPTIONS] DIRORFILE1 …`
+* `swiftgen run coredata [OPTIONS] DIRORFILE1 …`
+* `swiftgen run files [OPTIONS] DIRORFILE1 …`
+* `swiftgen run fonts [OPTIONS] DIRORFILE1 …`
+* `swiftgen run ib [OPTIONS] DIRORFILE1 …`
+* `swiftgen run json [OPTIONS] DIRORFILE1 …`
+* `swiftgen run plist [OPTIONS] DIRORFILE1 …`
+* `swiftgen run strings [OPTIONS] DIRORFILE1 …`
+* `swiftgen run xcassets [OPTIONS] DIRORFILE1 …`
+* `swiftgen run yaml [OPTIONS] DIRORFILE1 …`
+
+One rare cases where this might be useful — as opposed to using a config file — is if you are working on a custom template and want to quickly test the specific parser you're working on at each iteration/version of your custom template, until you're happy with it.
+
+Each parser command generally accepts the same options and syntax, and they mirror the options and parameters from the configuration file:
+
+* `--output FILE` or `-o FILE`: set the file where to write the generated code. If omitted, the generated code will be printed on `stdout`.
+* `--templateName NAME` or `-n NAME`: define the Stencil template to use (by name, see [here for more info](Documentation/templates)) to generate the output.
+* `--templatePath PATH` or `-p PATH`: define the Stencil template to use, using a full path.
+* Note: you should specify one and only one template when invoking SwiftGen. You have to use either `-t` or `-p` but should not use both at the same time (it wouldn't make sense anyway and you'll get an error if you try)
+* `--filter REGEX` or `-f REGEX`: the filter to apply to each input path. Filters are applied to actual (relative) paths, not just the filename. Each command has a default filter that you can override with this option.
+* Note: use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. Regular expressions will be case sensitive by default, and not anchored to the start/end of a path. For example, use `.+\.xib$` to match files with a `.xib` extension. Use a tool such as [RegExr](https://regexr.com) to ensure you're using a valid regular expression.
+* Each command supports multiple input files (or directories where applicable).
+* You can always use the `--help` flag to see what options a command accept, e.g. `swiftgen run xcassets --help`.
+
+</details>
+
+## Choosing your template
+
+SwiftGen is based on templates (it uses [Stencil](https://github.com/stencilproject/Stencil) as its template engine). This means that **you can choose the template that fits the Swift version you're using** — and also the one that best fits your preferences — to **adapt the generated code to your own conventions and Swift version**.
+
+### Bundled templates vs. Custom ones
+
+SwiftGen comes bundled with some templates for each of the parsers (`colors`, `coredata`, `files`, `fonts`, `ib`, `json`, `plist`, `strings`, `xcassets`, `yaml`), which will fit most needs; simply use the `templateName` output option to specify the name of the template to use. But you can also create your own templates if the bundled ones don't suit your coding conventions or needs: just store them anywhere (like in your project repository) and use the `templatePath` output option instead of `templateName`, to specify their path.
+
+💡 You can use the `swiftgen template list` command to list all the available bundled templates for each parser, and use `swiftgen template cat` to show a template's content and duplicate it to create your own variation.
+
+For more information about how to create your own templates, [see the dedicated documentation](Documentation/Articles/Creating-custom-templates.md).
+
+### Templates bundled with SwiftGen:
+
+As explained above, you can use `swiftgen template list` to list all templates bundled with SwiftGen. For most SwiftGen parsers, we provide, among others:
+
+* A `swift4` template, compatible with Swift 4
+* A `swift5` template, compatible with Swift 5
+* Other variants, like `flat-swift4/5` and `structured-swift4/5` templates for Strings, etc.
+
+You can **find the documentation for each bundled template [here in the repo](Documentation/templates)**, with documentation organized as one folder per SwiftGen parser, then one MarkDown file per template. You can also use `swiftgen template doc` to open that documentation page in your browser directly from your terminal.
+
+Each MarkDown file documents the Swift Version it's aimed for, the use case for that template (in which cases you might favor that template over others), the available parameters to customize it on invocation (using the `params:` key in your config file), and some code examples.
+
+> Don't hesitate to make PRs to share your improvements suggestions on the bundled templates 😉
+
+## Additional documentation
+
+### Playground
+
+The `SwiftGen.playground` available in this repository will allow you to play with the code that the tool typically generates, and see some examples of how you can take advantage of it.
+
+This allows you to have a quick look at how typical code generated by SwiftGen looks like, and how you will then use the generated constants in your code.
+
+### Dedicated Documentation in Markdown
+
+There is a lot of documentation in the form of Markdown files in this repository, and in the related [StencilSwiftKit](https://github.com/SwiftGen/StencilSwiftKit) repository as well.
+
+Be sure to [check the "Documentation" folder](Documentation/) of each repository.
+
+Especially, in addition to the previously mentioned [Migration Guide](Documentation/MigrationGuide.md) and [Configuration File](Documentation/ConfigFile.md) documentation, the `Documentation/` folder in the SwiftGen repository also includes:
+
+* A [`templates` subdirectory](Documentation/templates/) that details the documentation for each of the templates bundled with SwiftGen (when to use each template, what the output will look like, and custom parameters to adjust them, …)
+* A [`SwiftGenKit Contexts` subdirectory](Documentation/SwiftGenKit%20Contexts/) that details the structure of the "Stencil Contexts", i.e. the Dictionary/YAML representation resulting of parsing your input files. This documentation is useful for people wanting to write their own templates, so that they know the structure and various keys available when writing their template, to construct the wanted generated output accordingly.
+* [Various articles](Documentation/Articles/) to provide best practices & tips on how to better take advantage of SwiftGen in your projects:
+  * [Integrate SwiftGen in your Xcode project](Documentation/Articles/Xcode-Integration.md) — so it rebuilds the constants every time you build
+  * [Configure SwiftLint to help your developers use constants generated by SwiftGen](Documentation/Articles/SwiftLint-Integration.md)
+  * [Create a custom template](Documentation/Articles/Creating-custom-templates.md), and [watch a folder to auto-regenerate an output every time you save the template you're working on](Documentation/Articles/Watch-a-folder-for-changes.md)
+  * …and more
+
+### Tutorials
+
+You can also find other help & tutorial material on the internet, like [this classroom about Code Generation I gave at FrenchKit in Sept'17](https://github.com/FrenchKit/Mastering-code-generation-Classroom) — and its wiki detailing a step-by-step tutorial about installing and using SwiftGen (and Sourcery too)
+
+---
+
+# Available Parsers
+
+## Asset Catalog
+
+```yaml
+xcassets:
+  inputs: /dir/to/search/for/imageset/assets
+  outputs:
+    templateName: swift5
+    output: Assets.swift
+```
+
+This will generate an `enum Asset` with one `static let` per asset (image set, color set, data set, …) in your assets catalog, so that you can use them as constants.
+
+<details>
+<summary>Example of code generated by the bundled template</summary>
+
+```swift
+internal enum Asset {
+  internal enum Files {
+    internal static let data = DataAsset(value: "Data")
+    internal static let readme = DataAsset(value: "README")
+  }
+  internal enum Food {
+    internal enum Exotic {
+      internal static let banana = ImageAsset(value: "Exotic/Banana")
+      internal static let mango = ImageAsset(value: "Exotic/Mango")
+    }
+    internal static let `private` = ImageAsset(value: "private")
+  }
+  internal enum Styles {
+    internal enum Vengo {
+      internal static let primary = ColorAsset(value: "Vengo/Primary")
+      internal static let tint = ColorAsset(value: "Vengo/Tint")
+    }
+  }
+  internal enum Symbols {
+    internal static let exclamationMark = SymbolAsset(name: "Exclamation Mark")
+    internal static let plus = SymbolAsset(name: "Plus")
+  }
+  internal enum Targets {
+    internal static let bottles = ARResourceGroupAsset(name: "Bottles")
+    internal static let paintings = ARResourceGroupAsset(name: "Paintings")
+  }
+}
+```
+</details>
+
+### Usage Example
+
+```swift
+// You can create new images by referring to the enum instance and calling `.image` on it:
+let bananaImage = Asset.Exotic.banana.image
+let privateImage = Asset.private.image
+
+// You can create colors by referring to the enum instance and calling `.color` on it:
+let primaryColor = Asset.Styles.Vengo.primary.color
+let tintColor = Asset.Styles.Vengo.tint.color
+
+// You can create data items by referring to the enum instance and calling `.data` on it:
+let data = Asset.data.data
+let readme = Asset.readme.data
+
+// You can load an AR resource group's items using:
+let bottles = Asset.Targets.bottles.referenceObjects
+let paintings = Asset.Targets.paintings.referenceImages
+
+// You can create new symbol images by referring to the enum instance and calling `.image` on it (with or without configuration)
+let plus = Asset.Symbols.plus.image
+let style = UIImage.SymbolConfiguration(textStyle: .headline)
+let styled = Asset.Symbols.exclamationMark.image(with: style)
+```
+
+## Colors
+
+> ❗️ We recommend to define your colors in your Assets Catalogs and use the `xcassets` parser (see above) to generate color constants, instead of using this `colors` parser described below.  
+> The `colors` parser below is mainly useful if you support older versions of iOS where colors can't be defined in Asset Catalogs, or if you want to use Android's `colors.xml` files as input.
+
+```yaml
+colors:
+  inputs: /path/to/colors-file.txt
+  outputs:
+    templateName: swift5
+    output: Colors.swift
+```
+
+This will generate a `enum ColorName` with one `static let` per color listed in the text file passed as argument.
+
+The input file is expected to be either:
+
+* a [plain text file](Sources/TestUtils/Fixtures/Resources/Colors/extra.txt), with one line per color to register, each line being composed by the Name to give to the color, followed by ":", followed by the Hex representation of the color (like `rrggbb` or `rrggbbaa`, optionally prefixed by `#` or `0x`) or the name of another color in the file. Whitespaces are ignored.
+* a [JSON file](Sources/TestUtils/Fixtures/Resources/Colors/colors.json), representing a dictionary of names -> values, each value being the hex representation of the color
+* a [XML file](Sources/TestUtils/Fixtures/Resources/Colors/colors.xml), expected to be the same format as the Android colors.xml files, containing tags `<color name="AColorName">AColorHexRepresentation</color>`
+* a [`*.clr` file](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/DrawColor/Concepts/AboutColorLists.html#//apple_ref/doc/uid/20000757-BAJHJEDI) used by Apple's Color Palettes.
+
+For example you can use this command to generate colors from one of your system color lists:
+
+```yaml
+colors:
+  inputs: ~/Library/Colors/MyColors.clr
+  outputs:
+    templateName: swift5
+    output: Colors.swift
+```
+
+Generated code will look the same as if you'd use a text file.
+
+<details>
+<summary>Example of code generated by the bundled template</summary>
+
+Given the following `colors.txt` file:
+
+```
+Cyan-Color       : 0xff66ccff
+ArticleTitle     : #33fe66
+ArticleBody      : 339666
+ArticleFootnote  : ff66ccff
+Translucent      : ffffffcc
+```
+
+The generated code will look like this:
+
+```swift
+internal struct ColorName {
+  internal let rgbaValue: UInt32
+  internal var color: Color { return Color(named: self) }
+
+  /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
+  /// Alpha: 100% <br/> (0x339666ff)
+  internal static let articleBody = ColorName(rgbaValue: 0x339666ff)
+  /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#ff66cc"></span>
+  /// Alpha: 100% <br/> (0xff66ccff)
+  internal static let articleFootnote = ColorName(rgbaValue: 0xff66ccff)
+
+  ...
+}
+```
+</details>
+
+### Usage Example
+
+```swift
+// You can create colors with the convenience constructor like this:
+let title = UIColor(named: .articleBody)  // iOS
+let footnote = NSColor(named: .articleFootnote) // macOS
+
+// Or as an alternative, you can refer to enum instance and call .color on it:
+let sameTitle = ColorName.articleBody.color
+let sameFootnote = ColorName.articleFootnote.color
+```
+
+This way, no need to enter the color red, green, blue, alpha values each time and create ugly constants in the global namespace for them.
+
+## Core Data
+
+```yaml
+coredata:
+  inputs: /path/to/model.xcdatamodeld
+  outputs:
+    templateName: swift5
+    output: CoreData.swift
+```
+
+This will parse the specified core data model(s), generate a class for each entity in your model containing all the attributes, and a few extensions if needed for relationships and predefined fetch requests.
+
+<details>
+<summary>Example of code generated by the bundled template</summary>
+
+```swift
+internal class MainEntity: NSManagedObject {
+  internal class var entityName: String {
+    return "MainEntity"
+  }
+
+  internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
+  }
+
+  @nonobjc internal class func makeFetchRequest() -> NSFetchRequest<MainEntity> {
+    return NSFetchRequest<MainEntity>(entityName: entityName)
+  }
+
+  @NSManaged internal var attributedString: NSAttributedString?
+  @NSManaged internal var binaryData: Data?
+  @NSManaged internal var boolean: Bool
+  @NSManaged internal var date: Date?
+  @NSManaged internal var float: Float
+  @NSManaged internal var int64: Int64
+  internal var integerEnum: IntegerEnum {
+    get {
+      let key = "integerEnum"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
+      }
+      return result
+    }
+    set {
+      let key = "integerEnum"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue.rawValue, forKey: key)
+    }
+  }
+  @NSManaged internal var manyToMany: Set<SecondaryEntity>
+}
+
+// MARK: Relationship ManyToMany
+
+extension MainEntity {
+  @objc(addManyToManyObject:)
+  @NSManaged public func addToManyToMany(_ value: SecondaryEntity)
+
+  @objc(removeManyToManyObject:)
+  @NSManaged public func removeFromManyToMany(_ value: SecondaryEntity)
+
+  @objc(addManyToMany:)
+  @NSManaged public func addToManyToMany(_ values: Set<SecondaryEntity>)
+
+  @objc(removeManyToMany:)
+  @NSManaged public func removeFromManyToMany(_ values: Set<SecondaryEntity>)
+}
+```
+</details>
+
+### Usage Example
+
+```swift
+// Fetch all the instances of MainEntity
+let request = MainEntity.makeFetchRequest()
+let mainItems = try myContext.execute(request)
+
+// Type-safe relationships: `relatedItem` will be a `SecondaryEntity?` in this case
+let relatedItem = myMainItem.manyToMany.first
+```
+
+## Files
+
+```yaml
+files:
+  inputs: path/to/search
+  filter: .+\.mp4$
+  outputs:
+    templateName: structured-swift5
+    output: Files.swift
+```
+
+The files parser is intended to just list the name and mimetype of the files and subdirectories in a given directory. This will recursively search the specified directory using the given filter (default `.*`), defining a `struct File` for each matching file, and an hierarchical enum representing the directory structure of files.
+
+<details>
+<summary>Example of code generated by the bundled template</summary>
+
+```swift
+internal enum Files {
+  /// test.txt
+  internal static let testTxt = File(name: "test", ext: "txt", path: "", mimeType: "text/plain")
+  /// subdir/
+  internal enum Subdir {
+    /// subdir/A Video With Spaces.mp4
+    internal static let aVideoWithSpacesMp4 = File(name: "A Video With Spaces", ext: "mp4", path: "subdir", mimeType: "video/mp4")
+  }
+}
+```
+</details>
+
+### Usage Example
+
+```swift
+// Access files using the `url` or `path` fields
+let txt = Files.testTxt.url
+let video = Files.Subdir.aVideoWithSpacesMp4.path
+
+// In addition, there are `url(locale:)` and `path(locale:)` to specify a locale
+let localeTxt = Files.testTxt.url(locale: Locale.current)
+let localeVideo = Files.Subdir.aVideoWithSpacesMp4.path(locale: Locale.current)
+```
+
+### Flat Structure Support
+
+SwiftGen also has a template if you're not interested in keeping the folder structure in the generated code.
+
+<details>
+<summary>Example of code generated by the flat bundled template</summary>
+
+```swift
+internal enum Files {
+  /// test.txt
+  internal static let testTxt = File(name: "test", ext: "txt", path: "", mimeType: "text/plain")
+  /// subdir/A Video With Spaces.mp4
+  internal static let aVideoWithSpacesMp4 = File(name: "A Video With Spaces", ext: "mp4", path: "subdir", mimeType: "video/mp4")
+  }
+}
+```
+</details>
+
+Given the same file and folder structure as above the usage will now be:
+
+```swift
+// Access files using the `url` or `path` fields
+let txt = Files.testTxt.url
+let video = Files.aVideoWithSpacesMp4.path
+
+// In addition, there are `url(locale:)` and `path(locale:)` to specify a locale
+let localeTxt = Files.testTxt.url(locale: Locale.current)
+let localeVideo = Files.aVideoWithSpacesMp4.path(locale: Locale.current)
+```
+
+## Fonts
+
+```yaml
+fonts:
+  inputs: /path/to/font/dir
+  outputs:
+    templateName: swift5
+    output: Fonts.swift
+```
+
+This will recursively go through the specified directory, finding any typeface files (TTF, OTF, …), defining a `struct FontFamily` for each family, and an enum nested under that family that will represent the font styles.
+
+<details>
+<summary>Example of code generated by the bundled template</summary>
+
+```swift
+internal enum FontFamily {
+  internal enum SFNSDisplay: String, FontConvertible {
+    internal static let regular = FontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
+  }
+  internal enum ZapfDingbats: String, FontConvertible {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+  }
+}
+```
+</details>
+
+### Usage Example
+
+```swift
+// You can create fonts with the convenience constructor like this:
+let displayRegular = UIFont(font: FontFamily.SFNSDisplay.regular, size: 20.0) // iOS
+let dingbats = NSFont(font: FontFamily.ZapfDingbats.regular, size: 20.0)  // macOS
+
+// Or as an alternative, you can refer to enum instance and call .font on it:
+let sameDisplayRegular = FontFamily.SFNSDisplay.regular.font(size: 20.0)
+let sameDingbats = FontFamily.ZapfDingbats.regular.font(size: 20.0)
+```
+
+## Interface Builder
+
+```yaml
+ib:
+  inputs: /dir/to/search/for/storyboards
+  outputs:
+    - templateName: scenes-swift5
+      output: Storyboard Scenes.swift
+    - templateName: segues-swift5
+      output: Storyboard Segues.swift
+```
+
+This will generate an `enum` for each of your `NSStoryboard`/`UIStoryboard`, with respectively one `static let` per storyboard scene or segue.
+
+<details>
+<summary>Example of code generated by the bundled template</summary>
+
+The generated code will look like this:
+
+```swift
+// output from the scenes template
+
+internal enum StoryboardScene {
+  internal enum Dependency: StoryboardType {
+    internal static let storyboardName = "Dependency"
+
+    internal static let dependent = SceneType<UIViewController>(storyboard: Dependency.self, identifier: "Dependent")
+  }
+  internal enum Message: StoryboardType {
+    internal static let storyboardName = "Message"
+
+    internal static let messagesList = SceneType<UITableViewController>(storyboard: Message.self, identifier: "MessagesList")
+  }
+}
+
+// output from the segues template
+
+internal enum StoryboardSegue {
+  internal enum Message: String, SegueType {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+}
+```
+</details>
+
+### Usage Example
+
+```swift
+// You can instantiate scenes using the `instantiate` method:
+let vc = StoryboardScene.Dependency.dependent.instantiate()
+
+// You can perform segues using:
+vc.perform(segue: StoryboardSegue.Message.embed)
+
+// or match them (in prepareForSegue):
+override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+  switch StoryboardSegue.Message(segue) {
+  case .embed?:
+    // Prepare for your custom segue transition, passing information to the destination VC
+  case .customBack?:
+    // Prepare for your custom segue transition, passing information to the destination VC
+  default:
+    // Other segues from other scenes, not handled by this VC
+    break
+  }
+}
+```
+
+## JSON and YAML
+
+```yaml
+json:
+  inputs: /path/to/json/dir-or-file
+  outputs:
+    templateName: runtime-swift5
+    output: JSON.swift
+yaml:
+  inputs: /path/to/yaml/dir-or-file
+  outputs:
+    templateName: inline-swift5
+    output: YAML.swift
+```
+
+This will parse the given file, or when given a directory, recursively search for JSON and YAML files. It will define an `enum` for each file (and documents in a file where needed), and type-safe constants for the content of the file.
+
+Unlike other parsers, this one is intended to allow you to use more custom inputs (as the formats are quite open to your needs) to generate your code. This means that for these parsers (and the `plist` one), you'll probably be more likely to use custom templates to generate code properly adapted/tuned to your inputs, rather than using the bundled templates. To read more about writing your own custom templates, see [see the dedicated documentation](Documentation/Articles/Creating-custom-templates.md).
+
+<details>
+<summary>Example of code generated by the bundled template</summary>
+
+```swift
+internal enum JSONFiles {
+  internal enum Info {
+    private static let _document = JSONDocument(path: "info.json")
+    internal static let key1: String = _document["key1"]
+    internal static let key2: String = _document["key2"]
+    internal static let key3: [String: Any] = _document["key3"]
+  }
+  internal enum Sequence {
+    internal static let items: [Int] = objectFromJSON(at: "sequence.json")
+  }
+}
+```
+</details>
+
+### Usage Example
+
+```swift
+// This will be a dictionary
+let foo = JSONFiles.Info.key3
+
+// This will be an [Int]
+let bar = JSONFiles.Sequence.items
+```
+
+## Plists
+
+```yaml
+plist:
+  inputs: /path/to/plist/dir-or-file
+  outputs:
+    templateName: runtime-swift5
+    output: Plist.swift
+```
+
+This will parse the given file, or when given a directory, recursively search for Plist files. It will define an `enum` for each file (and documents in a file where needed), and type-safe constants for the content of the file.
+
+Unlike other parsers, this one is intended to allow you to use more custom inputs (as the format is quite open to your needs) to generate your code. This means that for this parser (and the `json` and `yaml` ones), you'll probably be more likely to use custom templates to generate code properly adapted/tuned to your inputs, rather than using the bundled templates. To read more about writing your own custom templates, see [see the dedicated documentation](Documentation/Articles/Creating-custom-templates.md).
+
+<details>
+<summary>Example of code generated by the bundled template</summary>
+
+```swift
+internal enum PlistFiles {
+  internal enum Test {
+    internal static let items: [String] = arrayFromPlist(at: "array.plist")
+  }
+  internal enum Stuff {
+    private static let _document = PlistDocument(path: "dictionary.plist")
+    internal static let key1: Int = _document["key1"]
+    internal static let key2: [String: Any] = _document["key2"]
+  }
+}
+```
+</details>
+
+### Usage Example
+
+```swift
+// This will be an array
+let foo = PlistFiles.Test.items
+
+// This will be an Int
+let bar = PlistFiles.Stuff.key1
+```
+
+## Strings
+
+```yaml
+strings:
+  inputs: /path/to/language.lproj
+  outputs:
+    templateName: structured-swift5
+    output: Strings.swift
+```
+
+This will generate a Swift `enum L10n` that will map all your `Localizable.strings` and `Localizable.stringsdict` (or other tables) keys to a `static let` constant. And if it detects placeholders like `%@`,`%d`,`%f`, it will generate a `static func` with the proper argument types instead, to provide type-safe formatting. By default it will add comments to the generated constants and functions using the comments from the strings file if present, or the default translation of the string.
+
+> Note that all dots within the key names are converted to dots in code (by using nested enums). You can provide a different separator than `.` to split key names into substructures by using a parser option – see [the parser documentation](Documentation/Parsers/strings.md).
+
+<details>
+<summary>Example of code generated by the structured bundled template</summary>
+
+Given the following `Localizable.strings` file:
+
+```swift
+/* Title for an alert */
+"alert_title" = "Title of the alert";
+"alert_message" = "Some alert body there";
+/* A comment with no space above it */
+"bananas.owner" = "Those %d bananas belong to %@.";
+```
+
+And the following `Localizable.stringsdict` file:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+  <dict>
+    <key>apples.count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@apples@</string>
+        <key>apples</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>zero</key>
+            <string>You have no apples</string>
+            <key>one</key>
+            <string>You have one apple</string>
+            <key>other</key>
+            <string>You have %d apples. Wow that is a lot!</string>
+        </dict>
+    </dict>
+  </dict>
+</plist>
+```
+
+> _Reminder: Don't forget to end each line in your `*.strings` files with a semicolon `;`! Now that in Swift code we don't need semi-colons, it's easy to forget it's still required by the `Localizable.strings` file format 😉_
+
+The generated code will contain this:
+
+```swift
+internal enum L10n {
+  /// Some alert body there
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  /// Title for an alert
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
+  internal enum Apples {
+    /// You have %d apples
+    internal static func count(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+    }
+  }
+  internal enum Bananas {
+    /// A comment with no space above it
+    internal static func owner(_ p1: Int, _ p2: Any) -> String {
+      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+    }
+  }
+}
+```
+Note that if the same key is present in both the `.strings` and the `.stringsdict` files, SwiftGen will only consider the one in the `.stringsdict` file, as that's also how Foundation behaves at runtime.
+
+</details>
+
+### Usage Example
+
+Once the code has been generated by the script, you can use it this way in your Swift code:
+
+```swift
+// Simple strings
+let message = L10n.alertMessage
+let title = L10n.alertTitle
+
+// with parameters, note that each argument needs to be of the correct type
+let apples = L10n.Apples.count(3)
+let bananas = L10n.Bananas.owner(5, "Olivier")
+```
+
+### Flat Strings Support
+
+SwiftGen also has a template to support flat strings files (i.e. without splitting the keys in substructures using "dot syntax"). The advantage is that your keys won't be mangled in any way; the disadvantage is that auto-completion won't be as nice.
+
+<details>
+<summary>Example of code generated by the flat bundled template</summary>
+
+```swift
+internal enum L10n {
+  /// Some alert body there
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  /// Title for an alert
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
+  /// You have %d apples
+  internal static func applesCount(_ p1: Int) -> String {
+    return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+  }
+  /// A comment with no space above it
+  internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+  }
+}
+```
+</details>
+
+Given the same `Localizable.strings` and `Localizable.stringsdict` as above the usage will now be:
+
+```swift
+// Simple strings
+let message = L10n.alertMessage
+let title = L10n.alertTitle
+
+// with parameters, note that each argument needs to be of the correct type
+let apples = L10n.applesCount(3)
+let bananas = L10n.bananasOwner(5, "Olivier")
+```
+
+---
+
+# Licence
+
+This code and tool is under the MIT Licence. See the `LICENCE` file in this repository.
+
+## Attributions
+
+This tool is powered by
+
+- [Stencil](https://github.com/stencilproject/Stencil) and few other libs by [Kyle Fuller](https://github.com/kylef)
+- SwiftGenKit and [StencilSwiftKit](https://github.com/SwiftGen/StencilSwiftKit), our internal frameworks at SwiftGen
+
+It is currently mainly maintained by [@AliSoftware](https://github.com/AliSoftware) and [@djbe](https://github.com/djbe). But I couldn't thank enough all the other [contributors](https://github.com/SwiftGen/SwiftGen/graphs/contributors) to this tool along the different versions which helped make SwiftGen awesome! 🎉
+
+If you want to contribute, don't hesitate to open a Pull Request, or even join the team!
+
+## Other Libraries / Tools
+
+If you want to also get rid of String-based APIs not only for your resources, but also for `UITableViewCell`, `UICollectionViewCell` and XIB-based views, you should take a look at my Mixin [Reusable](https://github.com/AliSoftware/Reusable).
+
+If you want to generate Swift code from your own Swift code (so meta!), like generate `Equatable` conformance to your types and a lot of other similar things, use [Sourcery](https://github.com/krzysztofzablocki/Sourcery).
+
+_SwiftGen and Sourcery are complementary tools. In fact, Sourcery uses `Stencil` too, as well as SwiftGen's `StencilSwiftKit` so you can use the exact same syntax for your templates for both!_
+
+You can also [follow me on twitter](http://twitter.com/aligatr) for news/updates about other projects I am creating, or [read my blog](https://alisoftware.github.io).

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Info.plist
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>21F79</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>SwiftGen_SwiftGenCLI</string>
+	<key>CFBundleIdentifier</key>
+	<string>SwiftGen.SwiftGenCLI.resources</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>SwiftGen_SwiftGenCLI</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>13F100</string>
+	<key>DTPlatformName</key>
+	<string>macosx</string>
+	<key>DTPlatformVersion</key>
+	<string>12.3</string>
+	<key>DTSDKBuild</key>
+	<string>21E226</string>
+	<key>DTSDKName</key>
+	<string>macosx12.3</string>
+	<key>DTXcode</key>
+	<string>1341</string>
+	<key>DTXcodeBuild</key>
+	<string>13F100</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.11</string>
+</dict>
+</plist>

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/colors/literals-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/colors/literals-swift4.stencil
@@ -1,0 +1,47 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if palettes %}
+{% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+#if os(macOS)
+  import AppKit
+  {% if enumName != 'NSColor' %}
+  {{accessModifier}} enum {{enumName}} { }
+  {% endif %}
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit
+  {% if enumName != 'UIColor' %}
+  {{accessModifier}} enum {{enumName}} { }
+  {% endif %}
+#endif
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Colors
+
+// swiftlint:disable identifier_name line_length type_body_length
+{{accessModifier}} extension {{enumName}} {
+{% macro h2f hex %}{{hex|hexToInt|int255toFloat}}{% endmacro %}
+{% macro enumBlock colors accessPrefix %}
+  {% for color in colors %}
+  /// 0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}} (r: {{color.red|hexToInt}}, g: {{color.green|hexToInt}}, b: {{color.blue|hexToInt}}, a: {{color.alpha|hexToInt}})
+  {{accessPrefix}}static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {%+ call h2f color.red %}, green: {%+ call h2f color.green %}, blue: {%+ call h2f color.blue %}, alpha: {%+ call h2f color.alpha %})
+  {% endfor %}
+{% endmacro %}
+  {% if palettes.count > 1 or param.forceFileNameEnum %}
+  {% set accessPrefix %}{{accessModifier}} {%+ endset %}
+  {% for palette in palettes %}
+  enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call enumBlock palette.colors accessPrefix %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call enumBlock palettes.first.colors "" %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length type_body_length
+{% else %}
+// No color found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/colors/literals-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/colors/literals-swift5.stencil
@@ -1,0 +1,47 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if palettes %}
+{% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+#if os(macOS)
+  import AppKit
+  {% if enumName != 'NSColor' %}
+  {{accessModifier}} enum {{enumName}} { }
+  {% endif %}
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit
+  {% if enumName != 'UIColor' %}
+  {{accessModifier}} enum {{enumName}} { }
+  {% endif %}
+#endif
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Colors
+
+// swiftlint:disable identifier_name line_length type_body_length
+{{accessModifier}} extension {{enumName}} {
+{% macro h2f hex %}{{hex|hexToInt|int255toFloat}}{% endmacro %}
+{% macro enumBlock colors accessPrefix %}
+  {% for color in colors %}
+  /// 0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}} (r: {{color.red|hexToInt}}, g: {{color.green|hexToInt}}, b: {{color.blue|hexToInt}}, a: {{color.alpha|hexToInt}})
+  {{accessPrefix}}static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {%+ call h2f color.red %}, green: {%+ call h2f color.green %}, blue: {%+ call h2f color.blue %}, alpha: {%+ call h2f color.alpha %})
+  {% endfor %}
+{% endmacro %}
+  {% if palettes.count > 1 or param.forceFileNameEnum %}
+  {% set accessPrefix %}{{accessModifier}} {%+ endset %}
+  {% for palette in palettes %}
+  enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call enumBlock palette.colors accessPrefix %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call enumBlock palettes.first.colors "" %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length type_body_length
+{% else %}
+// No color found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/colors/swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/colors/swift4.stencil
@@ -1,0 +1,82 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if palettes %}
+{% set colorAlias %}{{param.colorAliasName|default:"Color"}}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+#if os(macOS)
+  import AppKit.NSColor
+  {{accessModifier}} typealias {{colorAlias}} = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  {{accessModifier}} typealias {{colorAlias}} = UIColor
+#endif
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Colors
+
+// swiftlint:disable identifier_name line_length type_body_length
+{% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
+{{accessModifier}} struct {{enumName}} {
+  {{accessModifier}} let rgbaValue: UInt32
+  {{accessModifier}} var color: {{colorAlias}} { return {{colorAlias}}(named: self) }
+
+{% macro rgbaValue color %}0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}}{% endmacro %}
+{% macro enumBlock colors %}
+  {% for color in colors %}
+  /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#{{color.red}}{{color.green}}{{color.blue}}"></span>
+  /// Alpha: {{color.alpha|hexToInt|int255toFloat|percent}} <br/> (0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}})
+  {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}(rgbaValue: {%+ call rgbaValue color %})
+  {% endfor %}
+{% endmacro %}
+  {% if palettes.count > 1 or param.forceFileNameEnum %}
+  {% for palette in palettes %}
+  {{accessModifier}} enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call enumBlock palette.colors %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call enumBlock palettes.first.colors %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal extension {{colorAlias}} {
+  convenience init(rgbaValue: UInt32) {
+    let components = RGBAComponents(rgbaValue: rgbaValue).normalized
+    self.init(red: components[0], green: components[1], blue: components[2], alpha: components[3])
+  }
+}
+
+private struct RGBAComponents {
+  let rgbaValue: UInt32
+
+  private var shifts: [UInt32] {
+    [
+      rgbaValue >> 24, // red
+      rgbaValue >> 16, // green
+      rgbaValue >> 8,  // blue
+      rgbaValue        // alpha
+    ]
+  }
+
+  private var components: [CGFloat] {
+    shifts.map { CGFloat($0 & 0xff) }
+  }
+
+  var normalized: [CGFloat] {
+    components.map { $0 / 255.0 }
+  }
+}
+
+{{accessModifier}} extension {{colorAlias}} {
+  convenience init(named color: {{enumName}}) {
+    self.init(rgbaValue: color.rgbaValue)
+  }
+}
+{% else %}
+// No color found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/colors/swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/colors/swift5.stencil
@@ -1,0 +1,82 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if palettes %}
+{% set colorAlias %}{{param.colorAliasName|default:"Color"}}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+#if os(macOS)
+  import AppKit.NSColor
+  {{accessModifier}} typealias {{colorAlias}} = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  {{accessModifier}} typealias {{colorAlias}} = UIColor
+#endif
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Colors
+
+// swiftlint:disable identifier_name line_length type_body_length
+{% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
+{{accessModifier}} struct {{enumName}} {
+  {{accessModifier}} let rgbaValue: UInt32
+  {{accessModifier}} var color: {{colorAlias}} { return {{colorAlias}}(named: self) }
+
+{% macro rgbaValue color %}0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}}{% endmacro %}
+{% macro enumBlock colors %}
+  {% for color in colors %}
+  /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#{{color.red}}{{color.green}}{{color.blue}}"></span>
+  /// Alpha: {{color.alpha|hexToInt|int255toFloat|percent}} <br/> (0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}})
+  {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}(rgbaValue: {%+ call rgbaValue color %})
+  {% endfor %}
+{% endmacro %}
+  {% if palettes.count > 1 or param.forceFileNameEnum %}
+  {% for palette in palettes %}
+  {{accessModifier}} enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call enumBlock palette.colors %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call enumBlock palettes.first.colors %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal extension {{colorAlias}} {
+  convenience init(rgbaValue: UInt32) {
+    let components = RGBAComponents(rgbaValue: rgbaValue).normalized
+    self.init(red: components[0], green: components[1], blue: components[2], alpha: components[3])
+  }
+}
+
+private struct RGBAComponents {
+  let rgbaValue: UInt32
+
+  private var shifts: [UInt32] {
+    [
+      rgbaValue >> 24, // red
+      rgbaValue >> 16, // green
+      rgbaValue >> 8,  // blue
+      rgbaValue        // alpha
+    ]
+  }
+
+  private var components: [CGFloat] {
+    shifts.map { CGFloat($0 & 0xff) }
+  }
+
+  var normalized: [CGFloat] {
+    components.map { $0 / 255.0 }
+  }
+}
+
+{{accessModifier}} extension {{colorAlias}} {
+  convenience init(named color: {{enumName}}) {
+    self.init(rgbaValue: color.rgbaValue)
+  }
+}
+{% else %}
+// No color found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/coredata/swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/coredata/swift4.stencil
@@ -1,0 +1,231 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+// swiftlint:disable superfluous_disable_command implicit_return
+// swiftlint:disable sorted_imports
+import CoreData
+import Foundation
+{% for import in param.extraImports %}
+import {{ import }}
+{% empty %}
+{# If extraImports is a single String instead of an array, `for` considers it empty but we still have to check if there's a single String value #}
+{%- if param.extraImports %}
+import {{ param.extraImports }}
+{% endif %}
+{% endfor %}
+
+// swiftlint:disable attributes file_length vertical_whitespace_closing_braces
+// swiftlint:disable identifier_name line_length type_body_length
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+
+{% for model in models %}
+{% for name, entity in model.entities %}
+{% set superclass %}{{ model.entities[entity.superEntity].className|default:"NSManagedObject" }}{% endset %}
+{% set entityClassName %}{{ entity.className|default:"NSManagedObject" }}{% endset %}
+{% set hasChildren %}{% for aName,anEntity in model.entities where anEntity.superEntity == name %}1{% endfor %}{% endset %}
+// MARK: - {{ entity.name }}
+
+{% if not entity.shouldGenerateCode %}
+// Note: '{{ entity.name }}' has codegen enabled for Xcode, skipping code generation.
+
+{% elif entityClassName|contains:"." %}
+// Warning: '{{ entityClassName }}' cannot be a valid type name, skipping code generation.
+
+{% else %}
+{% if param.generateObjcName %}
+@objc({{ entityClassName }})
+{% endif %}
+{{ accessModifier }} {%+ if not entity.isAbstract and not hasChildren %}final {%+ endif %}class {{ entityClassName }}: {{ superclass }} {
+  {% set override %}{% if superclass != "NSManagedObject" %}override {%+ endif %}{% endset %}
+  {{ override }}{{ accessModifier }} class var entityName: String {
+    return "{{ entity.name }}"
+  }
+
+  {{ override }}{{ accessModifier }} class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
+  }
+
+  @available(*, deprecated, renamed: "makeFetchRequest", message: "To avoid collisions with the less concrete method in `NSManagedObject`, please use `makeFetchRequest()` instead.")
+  @nonobjc {{ accessModifier }} class func fetchRequest() -> NSFetchRequest<{{ entityClassName }}> {
+    return NSFetchRequest<{{ entityClassName }}>(entityName: entityName)
+  }
+
+  @nonobjc {{ accessModifier }} class func makeFetchRequest() -> NSFetchRequest<{{ entityClassName }}> {
+    return NSFetchRequest<{{ entityClassName }}>(entityName: entityName)
+  }
+
+  // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection implicit_getter
+  {% for attribute in entity.attributes %}
+  {% if attribute.userInfo.RawType %}
+  {% set rawType attribute.userInfo.RawType %}
+  {% set unwrapOptional attribute.userInfo.unwrapOptional %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ rawType }}{% if not unwrapOptional %}?{% endif %} {
+    get {
+      let key = "{{ attribute.name }}"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue else {
+        {%+ if unwrapOptional %}fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}.RawValue'"){% else %}return nil{% endif +%}
+      }
+      {% if attribute.userInfo.nonOptionalInit or not unwrapOptional %}
+      return {{ rawType }}(rawValue: value)
+      {% else %}
+      guard let result = {{ rawType }}(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}'")
+      }
+      return result
+      {% endif %}
+    }
+    {% if not attribute.isDerived %}
+    set {
+      let key = "{{ attribute.name }}"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue{% if not unwrapOptional %}?{% endif %}.rawValue, forKey: key)
+    }
+    {% endif %}
+  }
+  {% elif attribute.usesScalarValueType and attribute.isOptional %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
+    get {
+      let key = "{{ attribute.name }}"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? {{ attribute.typeName }}
+    }
+    {% if not attribute.isDerived %}
+    set {
+      let key = "{{ attribute.name }}"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+    {% endif %}
+  }
+  {% elif attribute.isDerived %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif %} {
+    let key = "{{ attribute.name }}"
+    willAccessValue(forKey: key)
+    defer { didAccessValue(forKey: key) }
+
+    {% if attribute.isOptional %}
+    return primitiveValue(forKey: key) as? {{ attribute.typeName }}
+    {% else %}
+    guard let value = primitiveValue(forKey: key) as? {{ attribute.typeName }} else {
+      fatalError("Could not convert value for key '\(key)' to type '{{ attribute.typeName }}'")
+    }
+    return value
+    {% endif %}
+  }
+  {% else %}
+  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif +%}
+  {% endif %}
+  {% endfor %}
+  {% for relationship in entity.relationships %}
+  {% if relationship.isToMany %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {%+ if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}>{% endif %}{% if relationship.isOptional %}?{% endif +%}
+  {% else %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}{% if relationship.isOptional %}?{% endif +%}
+  {% endif %}
+  {% endfor %}
+  {% for fetchedProperty in entity.fetchedProperties %}
+  @NSManaged {{ accessModifier }} var {{ fetchedProperty.name }}: [{{ model.entities[fetchedProperty.fetchRequest.entity].className|default:"NSManagedObject" }}]
+  {% endfor %}
+  // swiftlint:enable discouraged_optional_boolean discouraged_optional_collection implicit_getter
+}
+
+{% for relationship in entity.relationships where relationship.isToMany %}
+{% set destinationEntityClassName %}{{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}{% endset %}
+{% set collectionClassName %}{% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ destinationEntityClassName }}>{% endif %}{% endset %}
+{% set relationshipName %}{{ relationship.name | upperFirstLetter }}{% endset %}
+// MARK: Relationship {{ relationshipName }}
+
+extension {{ entityClassName }} {
+  {% if relationship.isOrdered %}
+  @objc(insertObject:in{{ relationshipName }}AtIndex:)
+  @NSManaged public func insertInto{{ relationshipName }}(_ value: {{ destinationEntityClassName }}, at idx: Int)
+
+  @objc(removeObjectFrom{{ relationshipName }}AtIndex:)
+  @NSManaged public func removeFrom{{ relationshipName }}(at idx: Int)
+
+  @objc(insert{{ relationshipName }}:atIndexes:)
+  @NSManaged public func insertInto{{ relationshipName }}(_ values: [{{ destinationEntityClassName }}], at indexes: NSIndexSet)
+
+  @objc(remove{{ relationshipName }}AtIndexes:)
+  @NSManaged public func removeFrom{{ relationshipName }}(at indexes: NSIndexSet)
+
+  @objc(replaceObjectIn{{ relationshipName }}AtIndex:withObject:)
+  @NSManaged public func replace{{ relationshipName }}(at idx: Int, with value: {{ destinationEntityClassName }})
+
+  @objc(replace{{ relationshipName }}AtIndexes:with{{ relationshipName }}:)
+  @NSManaged public func replace{{ relationshipName }}(at indexes: NSIndexSet, with values: [{{ destinationEntityClassName }}])
+
+  {% endif %}
+  @objc(add{{ relationshipName }}Object:)
+  @NSManaged public func addTo{{ relationshipName }}(_ value: {{ destinationEntityClassName }})
+
+  @objc(remove{{ relationshipName }}Object:)
+  @NSManaged public func removeFrom{{ relationshipName }}(_ value: {{ destinationEntityClassName }})
+
+  @objc(add{{ relationshipName }}:)
+  @NSManaged public func addTo{{ relationshipName }}(_ values: {{ collectionClassName }})
+
+  @objc(remove{{ relationshipName }}:)
+  @NSManaged public func removeFrom{{ relationshipName }}(_ values: {{ collectionClassName }})
+}
+
+{% endfor %}
+{% if model.fetchRequests[entity.name].count > 0 %}
+// MARK: Fetch Requests
+
+extension {{ entityClassName }} {
+  {% for fetchRequest in model.fetchRequests[entity.name] %}
+  {% set resultTypeName -%}
+    {%- if fetchRequest.resultType == "Object" -%}
+    {{ entityClassName }}
+    {%- elif fetchRequest.resultType == "Object ID" -%}
+    NSManagedObjectID
+    {%- elif fetchRequest.resultType == "Dictionary" -%}
+    [String: Any]
+    {%- endif -%}
+  {%- endset %}
+  class func fetch{{ fetchRequest.name | upperFirstLetter }}(managedObjectContext: NSManagedObjectContext
+    {%- for variableName, variableType in fetchRequest.substitutionVariables -%}
+    , {{ variableName | lowerFirstWord }}: {{ variableType }}
+    {%- endfor -%}
+  ) throws -> [{{ resultTypeName }}] {
+    guard let persistentStoreCoordinator = managedObjectContext.persistentStoreCoordinator else {
+      fatalError("Managed object context has no persistent store coordinator for getting fetch request templates")
+    }
+    let model = persistentStoreCoordinator.managedObjectModel
+    let substitutionVariables: [String: Any] = [
+      {% for variableName, variableType in fetchRequest.substitutionVariables %}
+      "{{ variableName }}": {{ variableName | lowerFirstWord }}{{ "," if not forloop.last }}
+      {% empty %}
+      :
+      {% endfor %}
+    ]
+
+    guard let fetchRequest = model.fetchRequestFromTemplate(withName: "{{ fetchRequest.name }}", substitutionVariables: substitutionVariables) else {
+      fatalError("No fetch request template named '{{ fetchRequest.name }}' found.")
+    }
+
+    guard let result = try managedObjectContext.fetch(fetchRequest) as? [{{ resultTypeName }}] else {
+      fatalError("Unable to cast fetch result to correct result type.")
+    }
+
+    return result
+  }
+
+  {% endfor %}
+}
+
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+// swiftlint:enable identifier_name line_length type_body_length

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/coredata/swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/coredata/swift5.stencil
@@ -1,0 +1,231 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+// swiftlint:disable superfluous_disable_command implicit_return
+// swiftlint:disable sorted_imports
+import CoreData
+import Foundation
+{% for import in param.extraImports %}
+import {{ import }}
+{% empty %}
+{# If extraImports is a single String instead of an array, `for` considers it empty but we still have to check if there's a single String value #}
+{%- if param.extraImports %}
+import {{ param.extraImports }}
+{% endif %}
+{% endfor %}
+
+// swiftlint:disable attributes file_length vertical_whitespace_closing_braces
+// swiftlint:disable identifier_name line_length type_body_length
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+
+{% for model in models %}
+{% for name, entity in model.entities %}
+{% set superclass %}{{ model.entities[entity.superEntity].className|default:"NSManagedObject" }}{% endset %}
+{% set entityClassName %}{{ entity.className|default:"NSManagedObject" }}{% endset %}
+{% set hasChildren %}{% for aName,anEntity in model.entities where anEntity.superEntity == name %}1{% endfor %}{% endset %}
+// MARK: - {{ entity.name }}
+
+{% if not entity.shouldGenerateCode %}
+// Note: '{{ entity.name }}' has codegen enabled for Xcode, skipping code generation.
+
+{% elif entityClassName|contains:"." %}
+// Warning: '{{ entityClassName }}' cannot be a valid type name, skipping code generation.
+
+{% else %}
+{% if param.generateObjcName %}
+@objc({{ entityClassName }})
+{% endif %}
+{{ accessModifier }} {%+ if not entity.isAbstract and not hasChildren %}final {%+ endif %}class {{ entityClassName }}: {{ superclass }} {
+  {% set override %}{% if superclass != "NSManagedObject" %}override {%+ endif %}{% endset %}
+  {{ override }}{{ accessModifier }} class var entityName: String {
+    return "{{ entity.name }}"
+  }
+
+  {{ override }}{{ accessModifier }} class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
+  }
+
+  @available(*, deprecated, renamed: "makeFetchRequest", message: "To avoid collisions with the less concrete method in `NSManagedObject`, please use `makeFetchRequest()` instead.")
+  @nonobjc {{ accessModifier }} class func fetchRequest() -> NSFetchRequest<{{ entityClassName }}> {
+    return NSFetchRequest<{{ entityClassName }}>(entityName: entityName)
+  }
+
+  @nonobjc {{ accessModifier }} class func makeFetchRequest() -> NSFetchRequest<{{ entityClassName }}> {
+    return NSFetchRequest<{{ entityClassName }}>(entityName: entityName)
+  }
+
+  // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection implicit_getter
+  {% for attribute in entity.attributes %}
+  {% if attribute.userInfo.RawType %}
+  {% set rawType attribute.userInfo.RawType %}
+  {% set unwrapOptional attribute.userInfo.unwrapOptional %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ rawType }}{% if not unwrapOptional %}?{% endif %} {
+    get {
+      let key = "{{ attribute.name }}"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue else {
+        {%+ if unwrapOptional %}fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}.RawValue'"){% else %}return nil{% endif +%}
+      }
+      {% if attribute.userInfo.nonOptionalInit or not unwrapOptional %}
+      return {{ rawType }}(rawValue: value)
+      {% else %}
+      guard let result = {{ rawType }}(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}'")
+      }
+      return result
+      {% endif %}
+    }
+    {% if not attribute.isDerived %}
+    set {
+      let key = "{{ attribute.name }}"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue{% if not unwrapOptional %}?{% endif %}.rawValue, forKey: key)
+    }
+    {% endif %}
+  }
+  {% elif attribute.usesScalarValueType and attribute.isOptional %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
+    get {
+      let key = "{{ attribute.name }}"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? {{ attribute.typeName }}
+    }
+    {% if not attribute.isDerived %}
+    set {
+      let key = "{{ attribute.name }}"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+    {% endif %}
+  }
+  {% elif attribute.isDerived %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif %} {
+    let key = "{{ attribute.name }}"
+    willAccessValue(forKey: key)
+    defer { didAccessValue(forKey: key) }
+
+    {% if attribute.isOptional %}
+    return primitiveValue(forKey: key) as? {{ attribute.typeName }}
+    {% else %}
+    guard let value = primitiveValue(forKey: key) as? {{ attribute.typeName }} else {
+      fatalError("Could not convert value for key '\(key)' to type '{{ attribute.typeName }}'")
+    }
+    return value
+    {% endif %}
+  }
+  {% else %}
+  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif +%}
+  {% endif %}
+  {% endfor %}
+  {% for relationship in entity.relationships %}
+  {% if relationship.isToMany %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {%+ if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}>{% endif %}{% if relationship.isOptional %}?{% endif +%}
+  {% else %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}{% if relationship.isOptional %}?{% endif +%}
+  {% endif %}
+  {% endfor %}
+  {% for fetchedProperty in entity.fetchedProperties %}
+  @NSManaged {{ accessModifier }} var {{ fetchedProperty.name }}: [{{ model.entities[fetchedProperty.fetchRequest.entity].className|default:"NSManagedObject" }}]
+  {% endfor %}
+  // swiftlint:enable discouraged_optional_boolean discouraged_optional_collection implicit_getter
+}
+
+{% for relationship in entity.relationships where relationship.isToMany %}
+{% set destinationEntityClassName %}{{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}{% endset %}
+{% set collectionClassName %}{% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ destinationEntityClassName }}>{% endif %}{% endset %}
+{% set relationshipName %}{{ relationship.name | upperFirstLetter }}{% endset %}
+// MARK: Relationship {{ relationshipName }}
+
+extension {{ entityClassName }} {
+  {% if relationship.isOrdered %}
+  @objc(insertObject:in{{ relationshipName }}AtIndex:)
+  @NSManaged public func insertInto{{ relationshipName }}(_ value: {{ destinationEntityClassName }}, at idx: Int)
+
+  @objc(removeObjectFrom{{ relationshipName }}AtIndex:)
+  @NSManaged public func removeFrom{{ relationshipName }}(at idx: Int)
+
+  @objc(insert{{ relationshipName }}:atIndexes:)
+  @NSManaged public func insertInto{{ relationshipName }}(_ values: [{{ destinationEntityClassName }}], at indexes: NSIndexSet)
+
+  @objc(remove{{ relationshipName }}AtIndexes:)
+  @NSManaged public func removeFrom{{ relationshipName }}(at indexes: NSIndexSet)
+
+  @objc(replaceObjectIn{{ relationshipName }}AtIndex:withObject:)
+  @NSManaged public func replace{{ relationshipName }}(at idx: Int, with value: {{ destinationEntityClassName }})
+
+  @objc(replace{{ relationshipName }}AtIndexes:with{{ relationshipName }}:)
+  @NSManaged public func replace{{ relationshipName }}(at indexes: NSIndexSet, with values: [{{ destinationEntityClassName }}])
+
+  {% endif %}
+  @objc(add{{ relationshipName }}Object:)
+  @NSManaged public func addTo{{ relationshipName }}(_ value: {{ destinationEntityClassName }})
+
+  @objc(remove{{ relationshipName }}Object:)
+  @NSManaged public func removeFrom{{ relationshipName }}(_ value: {{ destinationEntityClassName }})
+
+  @objc(add{{ relationshipName }}:)
+  @NSManaged public func addTo{{ relationshipName }}(_ values: {{ collectionClassName }})
+
+  @objc(remove{{ relationshipName }}:)
+  @NSManaged public func removeFrom{{ relationshipName }}(_ values: {{ collectionClassName }})
+}
+
+{% endfor %}
+{% if model.fetchRequests[entity.name].count > 0 %}
+// MARK: Fetch Requests
+
+extension {{ entityClassName }} {
+  {% for fetchRequest in model.fetchRequests[entity.name] %}
+  {% set resultTypeName -%}
+    {%- if fetchRequest.resultType == "Object" -%}
+    {{ entityClassName }}
+    {%- elif fetchRequest.resultType == "Object ID" -%}
+    NSManagedObjectID
+    {%- elif fetchRequest.resultType == "Dictionary" -%}
+    [String: Any]
+    {%- endif -%}
+  {%- endset %}
+  class func fetch{{ fetchRequest.name | upperFirstLetter }}(managedObjectContext: NSManagedObjectContext
+    {%- for variableName, variableType in fetchRequest.substitutionVariables -%}
+    , {{ variableName | lowerFirstWord }}: {{ variableType }}
+    {%- endfor -%}
+  ) throws -> [{{ resultTypeName }}] {
+    guard let persistentStoreCoordinator = managedObjectContext.persistentStoreCoordinator else {
+      fatalError("Managed object context has no persistent store coordinator for getting fetch request templates")
+    }
+    let model = persistentStoreCoordinator.managedObjectModel
+    let substitutionVariables: [String: Any] = [
+      {% for variableName, variableType in fetchRequest.substitutionVariables %}
+      "{{ variableName }}": {{ variableName | lowerFirstWord }}{{ "," if not forloop.last }}
+      {% empty %}
+      :
+      {% endfor %}
+    ]
+
+    guard let fetchRequest = model.fetchRequestFromTemplate(withName: "{{ fetchRequest.name }}", substitutionVariables: substitutionVariables) else {
+      fatalError("No fetch request template named '{{ fetchRequest.name }}' found.")
+    }
+
+    guard let result = try managedObjectContext.fetch(fetchRequest) as? [{{ resultTypeName }}] else {
+      fatalError("Unable to cast fetch result to correct result type.")
+    }
+
+    return result
+  }
+
+  {% endfor %}
+}
+
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+// swiftlint:enable identifier_name line_length type_body_length

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/files/flat-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/files/flat-swift4.stencil
@@ -1,0 +1,103 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if groups.count > 0 %}
+{% set enumName %}{{param.enumName|default:"Files"}}{% endset %}
+{% set useExt %}{% if param.useExtension|default:"true" %}true{% endif %}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set resourceType %}{{param.resourceTypeName|default:"File"}}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length line_length implicit_return
+
+// MARK: - Files
+
+{% macro groupBlock group %}
+  {% for file in group.files %}
+  {% call fileBlock file %}
+  {% endfor %}
+  {% for dir in group.directories %}
+  {% call dirBlock dir %}
+  {% endfor %}
+{% endmacro %}
+{% macro fileBlock file %}
+  /// {%+ if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif +%}
+  {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset %}
+  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {%+ if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
+{% endmacro %}
+{% macro dirBlock directory %}
+  {% for file in directory.files %}
+  {% call fileBlock file %}
+  {% endfor %}
+  {% for dir in directory.directories %}
+  {% call dirBlock dir %}
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable explicit_type_interface identifier_name
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+{{accessModifier}} enum {{enumName}} {
+  {% if groups.count > 1 or param.forceFileNameEnum %}
+  {% for group in groups %}
+  {{accessModifier}} enum {{group.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2 %}{% call groupBlock group %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call groupBlock groups.first %}
+  {% endif %}
+}
+// swiftlint:enable explicit_type_interface identifier_name
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
+
+{{accessModifier}} struct {{resourceType}} {
+  {{accessModifier}} let name: String
+  {{accessModifier}} let ext: String?
+  {{accessModifier}} let relativePath: String
+  {{accessModifier}} let mimeType: String
+
+  {{accessModifier}} var url: URL {
+    return url(locale: nil)
+  }
+
+  {{accessModifier}} func url(locale: Locale?) -> URL {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    let url = bundle.url(
+      forResource: name,
+      withExtension: ext,
+      subdirectory: relativePath,
+      localization: locale?.identifier
+    )
+    guard let result = url else {
+      let file = name + (ext.flatMap { ".\($0)" } ?? "")
+      fatalError("Could not locate file named \(file)")
+    }
+    return result
+  }
+
+  {{accessModifier}} var path: String {
+    return path(locale: nil)
+  }
+
+  {{accessModifier}} func path(locale: Locale?) -> String {
+    return url(locale: locale).path
+  }
+}
+{% if not param.bundle %}
+
+// swiftlint:disable convenience_type explicit_type_interface
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type explicit_type_interface
+{% endif %}
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/files/flat-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/files/flat-swift5.stencil
@@ -1,0 +1,103 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if groups.count > 0 %}
+{% set enumName %}{{param.enumName|default:"Files"}}{% endset %}
+{% set useExt %}{% if param.useExtension|default:"true" %}true{% endif %}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set resourceType %}{{param.resourceTypeName|default:"File"}}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length line_length implicit_return
+
+// MARK: - Files
+
+{% macro groupBlock group %}
+  {% for file in group.files %}
+  {% call fileBlock file %}
+  {% endfor %}
+  {% for dir in group.directories %}
+  {% call dirBlock dir %}
+  {% endfor %}
+{% endmacro %}
+{% macro fileBlock file %}
+  /// {%+ if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif +%}
+  {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset %}
+  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {%+ if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
+{% endmacro %}
+{% macro dirBlock directory %}
+  {% for file in directory.files %}
+  {% call fileBlock file %}
+  {% endfor %}
+  {% for dir in directory.directories %}
+  {% call dirBlock dir %}
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable explicit_type_interface identifier_name
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+{{accessModifier}} enum {{enumName}} {
+  {% if groups.count > 1 or param.forceFileNameEnum %}
+  {% for group in groups %}
+  {{accessModifier}} enum {{group.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2 %}{% call groupBlock group %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call groupBlock groups.first %}
+  {% endif %}
+}
+// swiftlint:enable explicit_type_interface identifier_name
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
+
+{{accessModifier}} struct {{resourceType}} {
+  {{accessModifier}} let name: String
+  {{accessModifier}} let ext: String?
+  {{accessModifier}} let relativePath: String
+  {{accessModifier}} let mimeType: String
+
+  {{accessModifier}} var url: URL {
+    return url(locale: nil)
+  }
+
+  {{accessModifier}} func url(locale: Locale?) -> URL {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    let url = bundle.url(
+      forResource: name,
+      withExtension: ext,
+      subdirectory: relativePath,
+      localization: locale?.identifier
+    )
+    guard let result = url else {
+      let file = name + (ext.flatMap { ".\($0)" } ?? "")
+      fatalError("Could not locate file named \(file)")
+    }
+    return result
+  }
+
+  {{accessModifier}} var path: String {
+    return path(locale: nil)
+  }
+
+  {{accessModifier}} func path(locale: Locale?) -> String {
+    return url(locale: locale).path
+  }
+}
+{% if not param.bundle %}
+
+// swiftlint:disable convenience_type explicit_type_interface
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type explicit_type_interface
+{% endif %}
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/files/structured-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/files/structured-swift4.stencil
@@ -1,0 +1,107 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if groups.count > 0 %}
+{% set enumName %}{{param.enumName|default:"Files"}}{% endset %}
+{% set useExt %}{% if param.useExtension|default:"true" %}true{% endif %}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set resourceType %}{{param.resourceTypeName|default:"File"}}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length line_length implicit_return
+
+// MARK: - Files
+
+{% macro groupBlock group %}
+  {% for file in group.files %}
+  {% call fileBlock file %}
+  {% endfor %}
+  {% for dir in group.directories %}
+  {% call dirBlock dir "" %}
+  {% endfor %}
+{% endmacro %}
+{% macro fileBlock file %}
+  /// {%+ if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif +%}
+  {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset %}
+  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {%+ if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
+{% endmacro %}
+{% macro dirBlock directory parent %}
+  {% set fullDir %}{{parent}}{{directory.name}}/{% endset %}
+  /// {{ fullDir }}
+  {{accessModifier}} enum {{directory.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% for file in directory.files %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+    {% endfor %}
+    {% for dir in directory.directories %}
+    {% filter indent:2," ",true %}{% call dirBlock dir fullDir %}{% endfilter %}
+    {% endfor %}
+  }
+{% endmacro %}
+// swiftlint:disable explicit_type_interface identifier_name
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+{{accessModifier}} enum {{enumName}} {
+  {% if groups.count > 1 or param.forceFileNameEnum %}
+  {% for group in groups %}
+  {{accessModifier}} enum {{group.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call groupBlock group %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call groupBlock groups.first %}
+  {% endif %}
+}
+// swiftlint:enable explicit_type_interface identifier_name
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
+
+{{accessModifier}} struct {{resourceType}} {
+  {{accessModifier}} let name: String
+  {{accessModifier}} let ext: String?
+  {{accessModifier}} let relativePath: String
+  {{accessModifier}} let mimeType: String
+
+  {{accessModifier}} var url: URL {
+    return url(locale: nil)
+  }
+
+  {{accessModifier}} func url(locale: Locale?) -> URL {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    let url = bundle.url(
+      forResource: name,
+      withExtension: ext,
+      subdirectory: relativePath,
+      localization: locale?.identifier
+    )
+    guard let result = url else {
+      let file = name + (ext.flatMap { ".\($0)" } ?? "")
+      fatalError("Could not locate file named \(file)")
+    }
+    return result
+  }
+
+  {{accessModifier}} var path: String {
+    return path(locale: nil)
+  }
+
+  {{accessModifier}} func path(locale: Locale?) -> String {
+    return url(locale: locale).path
+  }
+}
+{% if not param.bundle %}
+
+// swiftlint:disable convenience_type explicit_type_interface
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type explicit_type_interface
+{% endif %}
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/files/structured-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/files/structured-swift5.stencil
@@ -1,0 +1,107 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if groups.count > 0 %}
+{% set enumName %}{{param.enumName|default:"Files"}}{% endset %}
+{% set useExt %}{% if param.useExtension|default:"true" %}true{% endif %}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set resourceType %}{{param.resourceTypeName|default:"File"}}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length line_length implicit_return
+
+// MARK: - Files
+
+{% macro groupBlock group %}
+  {% for file in group.files %}
+  {% call fileBlock file %}
+  {% endfor %}
+  {% for dir in group.directories %}
+  {% call dirBlock dir "" %}
+  {% endfor %}
+{% endmacro %}
+{% macro fileBlock file %}
+  /// {%+ if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif +%}
+  {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset %}
+  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {%+ if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
+{% endmacro %}
+{% macro dirBlock directory parent %}
+  {% set fullDir %}{{parent}}{{directory.name}}/{% endset %}
+  /// {{ fullDir }}
+  {{accessModifier}} enum {{directory.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% for file in directory.files %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+    {% endfor %}
+    {% for dir in directory.directories %}
+    {% filter indent:2," ",true %}{% call dirBlock dir fullDir %}{% endfilter %}
+    {% endfor %}
+  }
+{% endmacro %}
+// swiftlint:disable explicit_type_interface identifier_name
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+{{accessModifier}} enum {{enumName}} {
+  {% if groups.count > 1 or param.forceFileNameEnum %}
+  {% for group in groups %}
+  {{accessModifier}} enum {{group.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call groupBlock group %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call groupBlock groups.first %}
+  {% endif %}
+}
+// swiftlint:enable explicit_type_interface identifier_name
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
+
+{{accessModifier}} struct {{resourceType}} {
+  {{accessModifier}} let name: String
+  {{accessModifier}} let ext: String?
+  {{accessModifier}} let relativePath: String
+  {{accessModifier}} let mimeType: String
+
+  {{accessModifier}} var url: URL {
+    return url(locale: nil)
+  }
+
+  {{accessModifier}} func url(locale: Locale?) -> URL {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    let url = bundle.url(
+      forResource: name,
+      withExtension: ext,
+      subdirectory: relativePath,
+      localization: locale?.identifier
+    )
+    guard let result = url else {
+      let file = name + (ext.flatMap { ".\($0)" } ?? "")
+      fatalError("Could not locate file named \(file)")
+    }
+    return result
+  }
+
+  {{accessModifier}} var path: String {
+    return path(locale: nil)
+  }
+
+  {{accessModifier}} func path(locale: Locale?) -> String {
+    return url(locale: locale).path
+  }
+}
+{% if not param.bundle %}
+
+// swiftlint:disable convenience_type explicit_type_interface
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type explicit_type_interface
+{% endif %}
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/fonts/swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/fonts/swift4.stencil
@@ -1,0 +1,110 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if families %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set fontType %}{{param.fontTypeName|default:"FontConvertible"}}{% endset %}
+#if os(macOS)
+  import AppKit.NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+#endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "{{fontType}}.Font", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.fontAliasName|default:"Font"}} = {{fontType}}.Font
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+// swiftlint:disable implicit_return
+
+// MARK: - Fonts
+
+// swiftlint:disable identifier_name line_length type_body_length
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
+    {{path}}
+  {%- else -%}
+    {{path|basename}}
+  {%- endif -%}
+{% endmacro %}
+{{accessModifier}} enum {{param.enumName|default:"FontFamily"}} {
+  {% for family in families %}
+  {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% for font in family.fonts %}
+    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{fontType}}(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
+    {% endfor %}
+    {{accessModifier}} static let all: [{{fontType}}] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{{ ", " if not forloop.last }}{% endfor %}]
+  }
+  {% endfor %}
+  {{accessModifier}} static let allCustomFonts: [{{fontType}}] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{{ ", " if not forloop.last }}{% endfor %}].flatMap { $0 }
+  {{accessModifier}} static func registerAllCustomFonts() {
+    allCustomFonts.forEach { $0.register() }
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+{{accessModifier}} struct {{fontType}} {
+  {{accessModifier}} let name: String
+  {{accessModifier}} let family: String
+  {{accessModifier}} let path: String
+
+  #if os(macOS)
+  {{accessModifier}} typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Font = UIFont
+  #endif
+
+  {{accessModifier}} func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  {{accessModifier}} func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    {% if param.lookupFunction %}
+    return {{param.lookupFunction}}(name, family, path)
+    {% else %}
+    return {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil)
+    {% endif %}
+  }
+}
+
+{{accessModifier}} extension {{fontType}}.Font {
+  convenience init?(font: {{fontType}}, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(macOS)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No fonts found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/fonts/swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/fonts/swift5.stencil
@@ -1,0 +1,162 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if families %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set fontType %}{{param.fontTypeName|default:"FontConvertible"}}{% endset %}
+#if os(macOS)
+  import AppKit.NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+#endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "{{fontType}}.Font", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.fontAliasName|default:"Font"}} = {{fontType}}.Font
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Fonts
+
+// swiftlint:disable identifier_name line_length type_body_length
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
+    {{path}}
+  {%- else -%}
+    {{path|basename}}
+  {%- endif -%}
+{% endmacro %}
+{{accessModifier}} enum {{param.enumName|default:"FontFamily"}} {
+  {% for family in families %}
+  {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% for font in family.fonts %}
+    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{fontType}}(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
+    {% endfor %}
+    {{accessModifier}} static let all: [{{fontType}}] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{{ ", " if not forloop.last }}{% endfor %}]
+  }
+  {% endfor %}
+  {{accessModifier}} static let allCustomFonts: [{{fontType}}] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{{ ", " if not forloop.last }}{% endfor %}].flatMap { $0 }
+  {{accessModifier}} static func registerAllCustomFonts() {
+    allCustomFonts.forEach { $0.register() }
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+{{accessModifier}} struct {{fontType}} {
+  {{accessModifier}} let name: String
+  {{accessModifier}} let family: String
+  {{accessModifier}} let path: String
+
+  #if os(macOS)
+  {{accessModifier}} typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Font = UIFont
+  #endif
+
+  {{accessModifier}} func font(size: CGFloat) -> Font {
+    guard let font = Font(font: self, size: size) else {
+      fatalError("Unable to initialize font '\(name)' (\(family))")
+    }
+    return font
+  }
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} func swiftUIFont(size: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  {{accessModifier}} func swiftUIFont(fixedSize: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, fixedSize: fixedSize)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  {{accessModifier}} func swiftUIFont(size: CGFloat, relativeTo textStyle: SwiftUI.Font.TextStyle) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size, relativeTo: textStyle)
+  }
+  #endif
+
+  {{accessModifier}} func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate func registerIfNeeded() {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: family).contains(name) {
+      register()
+    }
+    #elseif os(macOS)
+    if let url = url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      register()
+    }
+    #endif
+  }
+
+  fileprivate var url: URL? {
+    // swiftlint:disable:next implicit_return
+    {% if param.lookupFunction %}
+    return {{param.lookupFunction}}(name, family, path)
+    {% else %}
+    return {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil)
+    {% endif %}
+  }
+}
+
+{{accessModifier}} extension {{fontType}}.Font {
+  convenience init?(font: {{fontType}}, size: CGFloat) {
+    font.registerIfNeeded()
+    self.init(name: font.name, size: size)
+  }
+}
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+{{accessModifier}} extension SwiftUI.Font {
+  static func custom(_ font: {{fontType}}, size: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size)
+  }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+{{accessModifier}} extension SwiftUI.Font {
+  static func custom(_ font: {{fontType}}, fixedSize: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, fixedSize: fixedSize)
+  }
+
+  static func custom(
+    _ font: {{fontType}},
+    size: CGFloat,
+    relativeTo textStyle: SwiftUI.Font.TextStyle
+  ) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size, relativeTo: textStyle)
+  }
+}
+#endif
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No fonts found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/ib/scenes-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/ib/scenes-swift4.stencil
@@ -1,0 +1,159 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if platform and storyboards %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
+{% set prefix %}{% if isAppKit %}NS{% else %}UI{% endif %}{% endset %}
+{% set controller %}{% if isAppKit %}Controller{% else %}ViewController{% endif %}{% endset %}
+// swiftlint:disable sorted_imports
+import Foundation
+{% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
+import {{module}}
+{% endfor %}
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length implicit_return
+
+// MARK: - Storyboard Scenes
+
+// swiftlint:disable explicit_type_interface identifier_name line_length prefer_self_in_static_references
+// swiftlint:disable type_body_length type_name
+{% macro moduleName item %}
+  {%- if item.moduleIsPlaceholder -%}
+    {{ env.PRODUCT_MODULE_NAME|default:param.module }}
+  {%- else -%}
+    {{ item.module }}
+  {%- endif -%}
+{% endmacro %}
+{% macro className item %}
+  {%- set module %}{% call moduleName item %}{% endset -%}
+  {%- if module and ( not param.ignoreTargetModule or module != env.PRODUCT_MODULE_NAME and module != param.module ) -%}
+    {{module}}.
+  {%- endif -%}
+  {{item.type}}
+{%- endmacro %}
+{{accessModifier}} enum {{param.enumName|default:"StoryboardScene"}} {
+  {% for storyboard in storyboards %}
+  {% set storyboardName %}{{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}{% endset %}
+  {{accessModifier}} enum {{storyboardName}}: StoryboardType {
+    {{accessModifier}} static let storyboardName = "{{storyboard.name}}"
+    {% if storyboard.initialScene %}
+
+    {% set sceneClass %}{% call className storyboard.initialScene %}{% endset %}
+    {{accessModifier}} static let initialScene = InitialSceneType<{{sceneClass}}>(storyboard: {{storyboardName}}.self)
+    {% endif %}
+    {% for scene in storyboard.scenes %}
+
+    {% set sceneID %}{{scene.identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
+    {% set sceneClass %}{% call className scene %}{% endset %}
+    {{accessModifier}} static let {{sceneID}} = SceneType<{{sceneClass}}>(storyboard: {{storyboardName}}.self, identifier: "{{scene.identifier}}")
+    {% endfor %}
+  }
+  {% endfor %}
+}
+// swiftlint:enable explicit_type_interface identifier_name line_length prefer_self_in_static_references
+// swiftlint:enable type_body_length type_name
+
+// MARK: - Implementation Details
+
+{{accessModifier}} protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+{{accessModifier}} extension StoryboardType {
+  static var storyboard: {{prefix}}Storyboard {
+    let name = {%+ if isAppKit %}NSStoryboard.Name({% endif %}self.storyboardName{% if isAppKit %}){% endif +%}
+    {% if param.lookupFunction %}
+    return {{param.lookupFunction}}(name)
+    {% else %}
+    return {{prefix}}Storyboard(name: name, bundle: {{param.bundle|default:"BundleToken.bundle"}})
+    {% endif %}
+  }
+}
+
+{{accessModifier}} struct SceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
+  {{accessModifier}} let storyboard: StoryboardType.Type
+  {{accessModifier}} let identifier: String
+
+  {{accessModifier}} func instantiate() -> T {
+    let identifier = {%+ if isAppKit %}NSStoryboard.SceneIdentifier({% endif %}self.identifier{% if isAppKit %}){% endif +%}
+    guard let controller = storyboard.storyboard.instantiate{{controller}}(withIdentifier: identifier) as? T else {
+      fatalError("{{controller}} '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+
+  {% if isAppKit %}
+  @available(macOS 10.15, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T where T: NSViewController {
+    return storyboard.storyboard.instantiate{{controller}}(identifier: identifier, creator: block)
+  }
+
+  @available(macOS 10.15, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T where T: NSWindowController {
+    return storyboard.storyboard.instantiate{{controller}}(identifier: identifier, creator: block)
+  }
+  {% else %}
+  @available(iOS 13.0, tvOS 13.0, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T {
+    return storyboard.storyboard.instantiate{{controller}}(identifier: identifier, creator: block)
+  }
+  {% endif %}
+}
+
+{{accessModifier}} struct InitialSceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
+  {{accessModifier}} let storyboard: StoryboardType.Type
+
+  {{accessModifier}} func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}() as? T else {
+      fatalError("{{controller}} is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+
+  {% if isAppKit %}
+  @available(macOS 10.15, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T where T: NSViewController {
+    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}(creator: block) else {
+      fatalError("Storyboard \(storyboard.storyboardName) does not have an initial scene.")
+    }
+    return controller
+  }
+
+  @available(macOS 10.15, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T where T: NSWindowController {
+    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}(creator: block) else {
+      fatalError("Storyboard \(storyboard.storyboardName) does not have an initial scene.")
+    }
+    return controller
+  }
+  {% else %}
+  @available(iOS 13.0, tvOS 13.0, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T {
+    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}(creator: block) else {
+      fatalError("Storyboard \(storyboard.storyboardName) does not have an initial scene.")
+    }
+    return controller
+  }
+  {% endif %}
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% elif storyboards %}
+// Mixed AppKit and UIKit storyboard files found, please invoke swiftgen with these separately
+{% else %}
+// No storyboard found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/ib/scenes-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/ib/scenes-swift5.stencil
@@ -1,0 +1,159 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if platform and storyboards %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
+{% set prefix %}{% if isAppKit %}NS{% else %}UI{% endif %}{% endset %}
+{% set controller %}{% if isAppKit %}Controller{% else %}ViewController{% endif %}{% endset %}
+// swiftlint:disable sorted_imports
+import Foundation
+{% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
+import {{module}}
+{% endfor %}
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length implicit_return
+
+// MARK: - Storyboard Scenes
+
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+{% macro moduleName item %}
+  {%- if item.moduleIsPlaceholder -%}
+    {{ env.PRODUCT_MODULE_NAME|default:param.module }}
+  {%- else -%}
+    {{ item.module }}
+  {%- endif -%}
+{% endmacro %}
+{% macro className item %}
+  {%- set module %}{% call moduleName item %}{% endset -%}
+  {%- if module and ( not param.ignoreTargetModule or module != env.PRODUCT_MODULE_NAME and module != param.module ) -%}
+    {{module}}.
+  {%- endif -%}
+  {{item.type}}
+{%- endmacro %}
+{{accessModifier}} enum {{param.enumName|default:"StoryboardScene"}} {
+  {% for storyboard in storyboards %}
+  {% set storyboardName %}{{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}{% endset %}
+  {{accessModifier}} enum {{storyboardName}}: StoryboardType {
+    {{accessModifier}} static let storyboardName = "{{storyboard.name}}"
+    {% if storyboard.initialScene %}
+
+    {% set sceneClass %}{% call className storyboard.initialScene %}{% endset %}
+    {{accessModifier}} static let initialScene = InitialSceneType<{{sceneClass}}>(storyboard: Self.self)
+    {% endif %}
+    {% for scene in storyboard.scenes %}
+
+    {% set sceneID %}{{scene.identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
+    {% set sceneClass %}{% call className scene %}{% endset %}
+    {{accessModifier}} static let {{sceneID}} = SceneType<{{sceneClass}}>(storyboard: Self.self, identifier: "{{scene.identifier}}")
+    {% endfor %}
+  }
+  {% endfor %}
+}
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+{{accessModifier}} protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+{{accessModifier}} extension StoryboardType {
+  static var storyboard: {{prefix}}Storyboard {
+    let name = {%+ if isAppKit %}NSStoryboard.Name({% endif %}self.storyboardName{% if isAppKit %}){% endif +%}
+    {% if param.lookupFunction %}
+    return {{param.lookupFunction}}(name)
+    {% else %}
+    return {{prefix}}Storyboard(name: name, bundle: {{param.bundle|default:"BundleToken.bundle"}})
+    {% endif %}
+  }
+}
+
+{{accessModifier}} struct SceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
+  {{accessModifier}} let storyboard: StoryboardType.Type
+  {{accessModifier}} let identifier: String
+
+  {{accessModifier}} func instantiate() -> T {
+    let identifier = {%+ if isAppKit %}NSStoryboard.SceneIdentifier({% endif %}self.identifier{% if isAppKit %}){% endif +%}
+    guard let controller = storyboard.storyboard.instantiate{{controller}}(withIdentifier: identifier) as? T else {
+      fatalError("{{controller}} '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+
+  {% if isAppKit %}
+  @available(macOS 10.15, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T where T: NSViewController {
+    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
+    return storyboard.storyboard.instantiate{{controller}}(identifier: identifier, creator: block)
+  }
+
+  @available(macOS 10.15, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T where T: NSWindowController {
+    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
+    return storyboard.storyboard.instantiate{{controller}}(identifier: identifier, creator: block)
+  }
+  {% else %}
+  @available(iOS 13.0, tvOS 13.0, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T {
+    return storyboard.storyboard.instantiate{{controller}}(identifier: identifier, creator: block)
+  }
+  {% endif %}
+}
+
+{{accessModifier}} struct InitialSceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
+  {{accessModifier}} let storyboard: StoryboardType.Type
+
+  {{accessModifier}} func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}() as? T else {
+      fatalError("{{controller}} is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+
+  {% if isAppKit %}
+  @available(macOS 10.15, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T where T: NSViewController {
+    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}(creator: block) else {
+      fatalError("Storyboard \(storyboard.storyboardName) does not have an initial scene.")
+    }
+    return controller
+  }
+
+  @available(macOS 10.15, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T where T: NSWindowController {
+    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}(creator: block) else {
+      fatalError("Storyboard \(storyboard.storyboardName) does not have an initial scene.")
+    }
+    return controller
+  }
+  {% else %}
+  @available(iOS 13.0, tvOS 13.0, *)
+  {{accessModifier}} func instantiate(creator block: @escaping (NSCoder) -> T?) -> T {
+    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}(creator: block) else {
+      fatalError("Storyboard \(storyboard.storyboardName) does not have an initial scene.")
+    }
+    return controller
+  }
+  {% endif %}
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% elif storyboards %}
+// Mixed AppKit and UIKit storyboard files found, please invoke swiftgen with these separately
+{% else %}
+// No storyboard found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/ib/segues-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/ib/segues-swift4.stencil
@@ -1,0 +1,60 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if platform and storyboards %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
+// swiftlint:disable sorted_imports
+import Foundation
+{% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
+import {{module}}
+{% endfor %}
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Storyboard Segues
+
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+{{accessModifier}} enum {{param.enumName|default:"StoryboardSegue"}} {
+  {% for storyboard in storyboards where storyboard.segues %}
+  {{accessModifier}} enum {{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: String, SegueType {
+    {% for segue in storyboard.segues %}
+    {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
+    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif +%}
+    {% endfor %}
+  }
+  {% endfor %}
+}
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+{{accessModifier}} protocol SegueType: RawRepresentable {}
+
+{{accessModifier}} extension {%+ if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %} {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = {%+ if isAppKit %}NSStoryboardSegue.Identifier({% endif %}segue.rawValue{% if isAppKit %}){% endif +%}
+    performSegue{% if isAppKit %}?{% endif %}(withIdentifier: identifier, sender: sender)
+  }
+}
+
+{{accessModifier}} extension SegueType where RawValue == String {
+  init?(_ segue: {%+ if isAppKit %}NS{% else %}UI{% endif %}StoryboardSegue) {
+    {% if isAppKit %}
+    #if swift(>=4.2)
+    guard let identifier = segue.identifier else { return nil }
+    #else
+    guard let identifier = segue.identifier?.rawValue else { return nil }
+    #endif
+    {% else %}
+    guard let identifier = segue.identifier else { return nil }
+    {% endif %}
+    self.init(rawValue: identifier)
+  }
+}
+{% elif storyboards %}
+// Mixed AppKit and UIKit storyboard files found, please invoke swiftgen with these separately
+{% else %}
+// No storyboard found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/ib/segues-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/ib/segues-swift5.stencil
@@ -1,0 +1,60 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if platform and storyboards %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
+// swiftlint:disable sorted_imports
+import Foundation
+{% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
+import {{module}}
+{% endfor %}
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Storyboard Segues
+
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+{{accessModifier}} enum {{param.enumName|default:"StoryboardSegue"}} {
+  {% for storyboard in storyboards where storyboard.segues %}
+  {{accessModifier}} enum {{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: String, SegueType {
+    {% for segue in storyboard.segues %}
+    {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
+    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif +%}
+    {% endfor %}
+  }
+  {% endfor %}
+}
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+{{accessModifier}} protocol SegueType: RawRepresentable {}
+
+{{accessModifier}} extension {%+ if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %} {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = {%+ if isAppKit %}NSStoryboardSegue.Identifier({% endif %}segue.rawValue{% if isAppKit %}){% endif +%}
+    performSegue{% if isAppKit %}?{% endif %}(withIdentifier: identifier, sender: sender)
+  }
+}
+
+{{accessModifier}} extension SegueType where RawValue == String {
+  init?(_ segue: {%+ if isAppKit %}NS{% else %}UI{% endif %}StoryboardSegue) {
+    {% if isAppKit %}
+    #if swift(>=4.2)
+    guard let identifier = segue.identifier else { return nil }
+    #else
+    guard let identifier = segue.identifier?.rawValue else { return nil }
+    #endif
+    {% else %}
+    guard let identifier = segue.identifier else { return nil }
+    {% endif %}
+    self.init(rawValue: identifier)
+  }
+}
+{% elif storyboards %}
+// Mixed AppKit and UIKit storyboard files found, please invoke swiftgen with these separately
+{% else %}
+// No storyboard found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/json/inline-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/json/inline-swift4.stencil
@@ -1,0 +1,82 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+{% macro fileBlock file %}
+  {% call documentBlock file file.document %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% elif document.metadata.type == "Dictionary" %}
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
+  {% endfor %}
+  {% else %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- elif metadata.type == "Optional" -%}
+    Any?
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
+    "{{ value }}"
+  {%- elif metadata.type == "Optional" -%}
+    nil
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
+      {{ ", " if not forloop.last }}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
+      {{ ", " if not forloop.last }}
+    {%- empty -%}
+      :
+    {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
+  {%- else -%}
+    {{ value }}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+{{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/json/inline-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/json/inline-swift5.stencil
@@ -1,0 +1,82 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+{% macro fileBlock file %}
+  {% call documentBlock file file.document %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% elif document.metadata.type == "Dictionary" %}
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
+  {% endfor %}
+  {% else %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- elif metadata.type == "Optional" -%}
+    Any?
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
+    "{{ value }}"
+  {%- elif metadata.type == "Optional" -%}
+    nil
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
+      {{ ", " if not forloop.last }}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
+      {{ ", " if not forloop.last }}
+    {%- empty -%}
+      :
+    {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
+  {%- else -%}
+    {{ value }}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+{{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/json/runtime-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/json/runtime-swift4.stencil
@@ -1,0 +1,111 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+{% macro fileBlock file %}
+  {% call documentBlock file file.document %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = objectFromJSON(at: "{% call transformPath file.path %}")
+  {% elif document.metadata.type == "Dictionary" %}
+  private static let _document = JSONDocument(path: "{% call transformPath file.path %}")
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value %}
+  {% endfor %}
+  {% else %}
+  {{accessModifier}} static let value: {{rootType}} = objectFromJSON(at: "{% call transformPath file.path %}")
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- elif metadata.type == "Optional" -%}
+    Any?
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = _document["{{key}}"]
+{% endmacro %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
+    {{path}}
+  {%- else -%}
+    {{path|basename}}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length type_body_length
+{{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func objectFromJSON<T>(at path: String) -> T {
+  {% if param.lookupFunction %}
+  guard let url = {{param.lookupFunction}}(path),
+  {% else %}
+  guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+  {% endif %}
+    let json = try? JSONSerialization.jsonObject(with: Data(contentsOf: url), options: []),
+    let result = json as? T else {
+    fatalError("Unable to load JSON at path: \(path)")
+  }
+  return result
+}
+
+private struct JSONDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    self.data = objectFromJSON(at: path)
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/json/runtime-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/json/runtime-swift5.stencil
@@ -1,0 +1,111 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+{% macro fileBlock file %}
+  {% call documentBlock file file.document %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = objectFromJSON(at: "{% call transformPath file.path %}")
+  {% elif document.metadata.type == "Dictionary" %}
+  private static let _document = JSONDocument(path: "{% call transformPath file.path %}")
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value %}
+  {% endfor %}
+  {% else %}
+  {{accessModifier}} static let value: {{rootType}} = objectFromJSON(at: "{% call transformPath file.path %}")
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- elif metadata.type == "Optional" -%}
+    Any?
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = _document["{{key}}"]
+{% endmacro %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
+    {{path}}
+  {%- else -%}
+    {{path|basename}}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length type_body_length
+{{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func objectFromJSON<T>(at path: String) -> T {
+  {% if param.lookupFunction %}
+  guard let url = {{param.lookupFunction}}(path),
+  {% else %}
+  guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+  {% endif %}
+    let json = try? JSONSerialization.jsonObject(with: Data(contentsOf: url), options: []),
+    let result = json as? T else {
+    fatalError("Unable to load JSON at path: \(path)")
+  }
+  return result
+}
+
+private struct JSONDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    self.data = objectFromJSON(at: path)
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/plist/inline-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/plist/inline-swift4.stencil
@@ -1,0 +1,82 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+{% macro fileBlock file %}
+  {% call documentBlock file file.document %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% elif document.metadata.type == "Dictionary" %}
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
+  {% endfor %}
+  {% else %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
+    "{{ value }}"
+  {%- elif metadata.type == "Date" -%}
+    Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
+  {%- elif metadata.type == "Optional" -%}
+    nil
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
+      {{ ", " if not forloop.last }}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
+      {{ ", " if not forloop.last }}
+    {%- empty -%}
+      :
+    {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
+  {%- else -%}
+    {{ value }}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+{{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/plist/inline-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/plist/inline-swift5.stencil
@@ -1,0 +1,82 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+{% macro fileBlock file %}
+  {% call documentBlock file file.document %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% elif document.metadata.type == "Dictionary" %}
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
+  {% endfor %}
+  {% else %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
+    "{{ value }}"
+  {%- elif metadata.type == "Date" -%}
+    Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
+  {%- elif metadata.type == "Optional" -%}
+    nil
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
+      {{ ", " if not forloop.last }}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
+      {{ ", " if not forloop.last }}
+    {%- empty -%}
+      :
+    {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
+  {%- else -%}
+    {{ value }}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+{{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/plist/runtime-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/plist/runtime-swift4.stencil
@@ -1,0 +1,116 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+{% macro fileBlock file %}
+  {% call documentBlock file file.document %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = arrayFromPlist(at: "{% call transformPath file.path %}")
+  {% elif document.metadata.type == "Dictionary" %}
+  private static let _document = PlistDocument(path: "{% call transformPath file.path %}")
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value %}
+  {% endfor %}
+  {% else %}
+  // Unsupported root type `{{rootType}}`
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = _document["{{key}}"]
+{% endmacro %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
+    {{path}}
+  {%- else -%}
+    {{path|basename}}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length type_body_length
+{{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func arrayFromPlist<T>(at path: String) -> [T] {
+  {% if param.lookupFunction %}
+  guard let url = {{param.lookupFunction}}(path),
+  {% else %}
+  guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+  {% endif %}
+    let data = NSArray(contentsOf: url) as? [T] else {
+    fatalError("Unable to load PLIST at path: \(path)")
+  }
+  return data
+}
+
+private struct PlistDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    {% if param.lookupFunction %}
+    guard let url = {{param.lookupFunction}}(path),
+    {% else %}
+    guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+    {% endif %}
+      let data = NSDictionary(contentsOf: url) as? [String: Any] else {
+        fatalError("Unable to load PLIST at path: \(path)")
+    }
+    self.data = data
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/plist/runtime-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/plist/runtime-swift5.stencil
@@ -1,0 +1,116 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+{% macro fileBlock file %}
+  {% call documentBlock file file.document %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = arrayFromPlist(at: "{% call transformPath file.path %}")
+  {% elif document.metadata.type == "Dictionary" %}
+  private static let _document = PlistDocument(path: "{% call transformPath file.path %}")
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value %}
+  {% endfor %}
+  {% else %}
+  // Unsupported root type `{{rootType}}`
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = _document["{{key}}"]
+{% endmacro %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
+    {{path}}
+  {%- else -%}
+    {{path|basename}}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length type_body_length
+{{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func arrayFromPlist<T>(at path: String) -> [T] {
+  {% if param.lookupFunction %}
+  guard let url = {{param.lookupFunction}}(path),
+  {% else %}
+  guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+  {% endif %}
+    let data = NSArray(contentsOf: url) as? [T] else {
+    fatalError("Unable to load PLIST at path: \(path)")
+  }
+  return data
+}
+
+private struct PlistDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    {% if param.lookupFunction %}
+    guard let url = {{param.lookupFunction}}(path),
+    {% else %}
+    guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+    {% endif %}
+      let data = NSDictionary(contentsOf: url) as? [String: Any] else {
+        fatalError("Unable to load PLIST at path: \(path)")
+    }
+    self.data = data
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/flat-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/flat-swift4.stencil
@@ -1,0 +1,99 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if tables.count > 0 %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
+
+// MARK: - Strings
+
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
+    _ p{{forloop.counter}}: Any
+    {%- else -%}
+    _ p{{forloop.counter}}: {{type}}
+    {%- endif -%}
+    {{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
+    String(describing: p{{forloop.counter}})
+    {%- elif type == "UnsafeRawPointer" -%}
+    Int(bitPattern: p{{forloop.counter}})
+    {%- else -%}
+    p{{forloop.counter}}
+    {%- endif -%}
+    {{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro recursiveBlock table item %}
+  {% for string in item.strings %}
+  {% if not param.noComments %}
+  {% for line in string.comment|default:string.translation|split:"\n" %}
+  /// {{line}}
+  {% endfor %}
+  {% endif %}
+  {% set translation string.translation|replace:'"','\"'|replace:'	','\t' %}
+  {% if string.types %}
+  {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
+  }
+  {% elif param.lookupFunction %}
+  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}") }
+  {% else %}
+  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}")
+  {% endif %}
+  {% endfor %}
+  {% for child in item.children %}
+  {% call recursiveBlock table child %}
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
+{% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
+{{accessModifier}} enum {{enumName}} {
+  {% if tables.count > 1 or param.forceFileNameEnum %}
+  {% for table in tables %}
+  {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call recursiveBlock tables.first.name tables.first.levels %}
+  {% endif %}
+}
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+extension {{enumName}} {
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg..., fallback value: String) -> String {
+    {% if param.lookupFunction %}
+    let format = {{ param.lookupFunction }}(key, table, value)
+    {% else %}
+    let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
+    {% endif %}
+    return String(format: format, locale: Locale.current, arguments: args)
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No string found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/flat-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/flat-swift5.stencil
@@ -1,0 +1,99 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if tables.count > 0 %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
+
+// MARK: - Strings
+
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
+    _ p{{forloop.counter}}: Any
+    {%- else -%}
+    _ p{{forloop.counter}}: {{type}}
+    {%- endif -%}
+    {{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
+    String(describing: p{{forloop.counter}})
+    {%- elif type == "UnsafeRawPointer" -%}
+    Int(bitPattern: p{{forloop.counter}})
+    {%- else -%}
+    p{{forloop.counter}}
+    {%- endif -%}
+    {{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro recursiveBlock table item %}
+  {% for string in item.strings %}
+  {% if not param.noComments %}
+  {% for line in string.comment|default:string.translation|split:"\n" %}
+  /// {{line}}
+  {% endfor %}
+  {% endif %}
+  {% set translation string.translation|replace:'"','\"'|replace:'	','\t' %}
+  {% if string.types %}
+  {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
+  }
+  {% elif param.lookupFunction %}
+  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}") }
+  {% else %}
+  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}")
+  {% endif %}
+  {% endfor %}
+  {% for child in item.children %}
+  {% call recursiveBlock table child %}
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
+{% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
+{{accessModifier}} enum {{enumName}} {
+  {% if tables.count > 1 or param.forceFileNameEnum %}
+  {% for table in tables %}
+  {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call recursiveBlock tables.first.name tables.first.levels %}
+  {% endif %}
+}
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+extension {{enumName}} {
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg..., fallback value: String) -> String {
+    {% if param.lookupFunction %}
+    let format = {{ param.lookupFunction }}(key, table, value)
+    {% else %}
+    let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
+    {% endif %}
+    return String(format: format, locale: Locale.current, arguments: args)
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No string found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/objc-h.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/objc-h.stencil
@@ -1,0 +1,68 @@
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if tables.count > 0 %}
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    ({% call paramTranslate type %})p{{ forloop.counter }}{{ " :" if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    p{{forloop.counter}}{{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro paramTranslate swiftType %}
+  {%- if swiftType == "Any" -%}
+    id
+  {%- elif swiftType == "CChar" -%}
+    char
+  {%- elif swiftType == "Float" -%}
+    float
+  {%- elif swiftType == "Int" -%}
+    NSInteger
+  {%- elif swiftType == "String" -%}
+    id
+  {%- elif swiftType == "UnsafePointer<CChar>" -%}
+    char*
+  {%- elif swiftType == "UnsafeRawPointer" -%}
+    void*
+  {%- else -%}
+    objc-h.stencil is missing '{{swiftType}}'
+  {%- endif -%}
+{% endmacro %}
+{% macro emitOneMethod table item %}
+{% for string in item.strings %}
+{% if not param.noComments %}
+{% for line in string.comment|default:string.translation|split:"\n" %}
+/// {{line}}
+{% endfor %}
+{% endif %}
+{% if string.types %}
+  {% if string.types.count == 1 %}
++ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValue:{% call parametersBlock string.types %};
+  {% else %}
++ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValues:{% call parametersBlock string.types %};
+  {% endif %}
+{% else %}
++ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}};
+{% endif %}
+{% endfor %}
+{% for child in item.children %}
+{% call emitOneMethod table child %}
+{% endfor %}
+{% endmacro %}
+{% for table in tables %}
+@interface {{ table.name }} : NSObject
+    {% call emitOneMethod table.name table.levels %}
+@end
+
+{% endfor %}
+
+NS_ASSUME_NONNULL_END
+{% else %}
+// No strings found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/objc-m.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/objc-m.stencil
@@ -1,0 +1,90 @@
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if tables.count > 0 %}
+#import "{{ param.headerName|default:"Localizable.h" }}"
+{% if not param.bundle %}
+
+@interface BundleToken : NSObject
+@end
+
+@implementation BundleToken
+@end
+{% endif %}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-security"
+
+static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
+    NSBundle *bundle = {{param.bundle|default:"[NSBundle bundleForClass:BundleToken.class]"}};
+    NSString *format = [bundle localizedStringForKey:key value:value table:tableName];
+    NSLocale *locale = [NSLocale currentLocale];
+
+    va_list args;
+    va_start(args, value);
+    NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
+    va_end(args);
+
+    return result;
+};
+#pragma clang diagnostic pop
+
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    ({% call paramTranslate type %})p{{ forloop.counter }}{{ " :" if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    p{{forloop.counter}}{{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro paramTranslate swiftType %}
+  {%- if swiftType == "Any" -%}
+    id
+  {%- elif swiftType == "CChar" -%}
+    char
+  {%- elif swiftType == "Float" -%}
+    float
+  {%- elif swiftType == "Int" -%}
+    NSInteger
+  {%- elif swiftType == "String" -%}
+    id
+  {%- elif swiftType == "UnsafePointer<CChar>" -%}
+    char*
+  {%- elif swiftType == "UnsafeRawPointer" -%}
+    void*
+  {%- else -%}
+    objc-m.stencil is missing '{{swiftType}}'
+  {%- endif -%}
+{% endmacro %}
+{% macro tableContents table item %}
+  {% for string in item.strings %}
+  {% if string.types %}
+    {% if string.types.count == 1 %}
++ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValue:{% call parametersBlock string.types +%}
+    {% else %}
++ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValues:{% call parametersBlock string.types +%}
+    {% endif %}
+{
+    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'|replace:'	','\t'}}", {%+ call argumentsBlock string.types %});
+}
+{% else %}
++ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}} {
+    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'|replace:'	','\t'}}");
+}
+  {% endif %}
+  {% endfor %}
+  {% for child in item.children %}
+  {% call tableContents table child %}
+  {% endfor %}
+{% endmacro %}
+{% for table in tables %}
+        {% set tableName %}{{table.name|default:"Localized"}}{% endset %}
+@implementation {{ tableName }} : NSObject
+        {% call tableContents table.name table.levels %}
+@end
+
+{% endfor %}
+{% else %}
+// No strings found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/structured-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/structured-swift4.stencil
@@ -1,0 +1,103 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if tables.count > 0 %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
+
+// MARK: - Strings
+
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
+    _ p{{forloop.counter}}: Any
+    {%- else -%}
+    _ p{{forloop.counter}}: {{type}}
+    {%- endif -%}
+    {{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
+    String(describing: p{{forloop.counter}})
+    {%- elif type == "UnsafeRawPointer" -%}
+    Int(bitPattern: p{{forloop.counter}})
+    {%- else -%}
+    p{{forloop.counter}}
+    {%- endif -%}
+    {{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro recursiveBlock table item %}
+  {% for string in item.strings %}
+  {% if not param.noComments %}
+  {% for line in string.comment|default:string.translation|split:"\n" %}
+  /// {{line}}
+  {% endfor %}
+  {% endif %}
+  {% set translation string.translation|replace:'"','\"'|replace:'	','\t' %}
+  {% if string.types %}
+  {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
+  }
+  {% elif param.lookupFunction %}
+  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}") }
+  {% else %}
+  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}")
+  {% endif %}
+  {% endfor %}
+  {% for child in item.children %}
+  {{accessModifier}} enum {{child.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call recursiveBlock table child %}{% endfilter %}
+  }
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+{% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
+{{accessModifier}} enum {{enumName}} {
+  {% if tables.count > 1 or param.forceFileNameEnum %}
+  {% for table in tables %}
+  {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call recursiveBlock tables.first.name tables.first.levels %}
+  {% endif %}
+}
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
+
+extension {{enumName}} {
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg..., fallback value: String) -> String {
+    {% if param.lookupFunction %}
+    let format = {{ param.lookupFunction }}(key, table, value)
+    {% else %}
+    let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
+    {% endif %}
+    return String(format: format, locale: Locale.current, arguments: args)
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No string found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/structured-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/strings/structured-swift5.stencil
@@ -1,0 +1,103 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if tables.count > 0 %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
+
+// MARK: - Strings
+
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
+    _ p{{forloop.counter}}: Any
+    {%- else -%}
+    _ p{{forloop.counter}}: {{type}}
+    {%- endif -%}
+    {{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
+    String(describing: p{{forloop.counter}})
+    {%- elif type == "UnsafeRawPointer" -%}
+    Int(bitPattern: p{{forloop.counter}})
+    {%- else -%}
+    p{{forloop.counter}}
+    {%- endif -%}
+    {{ ", " if not forloop.last }}
+  {%- endfor -%}
+{% endmacro %}
+{% macro recursiveBlock table item %}
+  {% for string in item.strings %}
+  {% if not param.noComments %}
+  {% for line in string.comment|default:string.translation|split:"\n" %}
+  /// {{line}}
+  {% endfor %}
+  {% endif %}
+  {% set translation string.translation|replace:'"','\"'|replace:'	','\t' %}
+  {% if string.types %}
+  {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
+  }
+  {% elif param.lookupFunction %}
+  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}") }
+  {% else %}
+  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}")
+  {% endif %}
+  {% endfor %}
+  {% for child in item.children %}
+  {{accessModifier}} enum {{child.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call recursiveBlock table child %}{% endfilter %}
+  }
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+{% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
+{{accessModifier}} enum {{enumName}} {
+  {% if tables.count > 1 or param.forceFileNameEnum %}
+  {% for table in tables %}
+  {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call recursiveBlock tables.first.name tables.first.levels %}
+  {% endif %}
+}
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
+
+extension {{enumName}} {
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg..., fallback value: String) -> String {
+    {% if param.lookupFunction %}
+    let format = {{ param.lookupFunction }}(key, table, value)
+    {% else %}
+    let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
+    {% endif %}
+    return String(format: format, locale: Locale.current, arguments: args)
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No string found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/xcassets/swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/xcassets/swift4.stencil
@@ -1,0 +1,355 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if catalogs %}
+{% macro hasValuesBlock assets filter %}
+  {%- for asset in assets -%}
+    {%- if asset.type == filter -%}
+      1
+    {%- elif asset.items -%}
+      {% call hasValuesBlock asset.items filter %}
+    {%- endif -%}
+  {%- endfor -%}
+{% endmacro %}
+{% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
+{% set arResourceGroupType %}{{param.arResourceGroupTypeName|default:"ARResourceGroupAsset"}}{% endset %}
+{% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
+{% set dataType %}{{param.dataTypeName|default:"DataAsset"}}{% endset %}
+{% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
+{% set symbolType %}{{param.symbolTypeName|default:"SymbolAsset"}}{% endset %}
+{% set forceNamespaces %}{{param.forceProvidesNamespaces|default:"false"}}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set hasARResourceGroup %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "arresourcegroup" %}{% endfor %}{% endset %}
+{% set hasColor %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "color" %}{% endfor %}{% endset %}
+{% set hasData %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "data" %}{% endfor %}{% endset %}
+{% set hasImage %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "image" %}{% endfor %}{% endset %}
+{% set hasSymbol %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "symbol" %}{% endfor %}{% endset %}
+#if os(macOS)
+  import AppKit
+#elseif os(iOS)
+{% if hasARResourceGroup %}
+  import ARKit
+{% endif %}
+  import UIKit
+#elseif os(tvOS) || os(watchOS)
+  import UIKit
+#endif
+
+// Deprecated typealiases
+{% if hasColor %}
+@available(*, deprecated, renamed: "{{colorType}}.Color", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.colorAliasName|default:"AssetColorTypeAlias"}} = {{colorType}}.Color
+{% endif %}
+{% if hasImage %}
+@available(*, deprecated, renamed: "{{imageType}}.Image", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.imageAliasName|default:"AssetImageTypeAlias"}} = {{imageType}}.Image
+{% endif %}
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Asset Catalogs
+
+{% macro enumBlock assets %}
+  {% call casesBlock assets %}
+  {% if param.allValues %}
+
+  // swiftlint:disable trailing_comma
+  {% set hasItems %}{% call hasValuesBlock assets "arresourcegroup" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allResourceGroups: [{{arResourceGroupType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "arresourcegroup" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "color" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allColors: [{{colorType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "color" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "data" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allDataAssets: [{{dataType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "data" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "image" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allImages: [{{imageType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "image" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "symbol" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allSymbols: [{{symbolType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "symbol" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  // swiftlint:enable trailing_comma
+  {% endif %}
+{% endmacro %}
+{% macro casesBlock assets %}
+  {% for asset in assets %}
+  {% if asset.type == "arresourcegroup" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{arResourceGroupType}}(name: "{{asset.value}}")
+  {% elif asset.type == "color" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{colorType}}(name: "{{asset.value}}")
+  {% elif asset.type == "data" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{dataType}}(name: "{{asset.value}}")
+  {% elif asset.type == "image" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{imageType}}(name: "{{asset.value}}")
+  {% elif asset.type == "symbol" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{symbolType}}(name: "{{asset.value}}")
+  {% elif asset.items and ( forceNamespaces == "true" or asset.isNamespaced == "true" ) %}
+  {{accessModifier}} enum {{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call casesBlock asset.items %}{% endfilter %}
+  }
+  {% elif asset.items %}
+  {% call casesBlock asset.items %}
+  {% endif %}
+  {% endfor %}
+{% endmacro %}
+{% macro allValuesBlock assets filter prefix %}
+  {% for asset in assets %}
+  {% if asset.type == filter %}
+  {{prefix}}{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}},
+  {% elif asset.items and ( forceNamespaces == "true" or asset.isNamespaced == "true" ) %}
+  {% set prefix2 %}{{prefix}}{{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.{% endset %}
+  {% call allValuesBlock asset.items filter prefix2 %}
+  {% elif asset.items %}
+  {% call allValuesBlock asset.items filter prefix %}
+  {% endif %}
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+{{accessModifier}} enum {{enumName}} {
+  {% if catalogs.count > 1 or param.forceFileNameEnum %}
+  {% for catalog in catalogs %}
+  {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% if catalog.assets %}
+    {% filter indent:2," ",true %}{% call enumBlock catalog.assets %}{% endfilter %}
+    {% endif %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call enumBlock catalogs.first.assets %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+{% if hasARResourceGroup %}
+
+{{accessModifier}} struct {{arResourceGroupType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(iOS)
+  @available(iOS 11.3, *)
+  {{accessModifier}} var referenceImages: Set<ARReferenceImage> {
+    return ARReferenceImage.referenceImages(in: self)
+  }
+
+  @available(iOS 12.0, *)
+  {{accessModifier}} var referenceObjects: Set<ARReferenceObject> {
+    return ARReferenceObject.referenceObjects(in: self)
+  }
+  #endif
+}
+
+#if os(iOS)
+@available(iOS 11.3, *)
+{{accessModifier}} extension ARReferenceImage {
+  static func referenceImages(in asset: {{arResourceGroupType}}) -> Set<ARReferenceImage> {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    return referenceImages(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+
+@available(iOS 12.0, *)
+{{accessModifier}} extension ARReferenceObject {
+  static func referenceObjects(in asset: {{arResourceGroupType}}) -> Set<ARReferenceObject> {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    return referenceObjects(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+#endif
+{% endif %}
+{% if hasColor %}
+
+{{accessModifier}} final class {{colorType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(macOS)
+  {{accessModifier}} typealias Color = NSColor
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Color = UIColor
+  #endif
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  {{accessModifier}} private(set) lazy var color: Color = Color(asset: self)
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 11.0, tvOS 11.0, *)
+  {{accessModifier}} func color(compatibleWith traitCollection: UITraitCollection) -> Color {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }
+  #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
+}
+
+{{accessModifier}} extension {{colorType}}.Color {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  convenience init!(asset: {{colorType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+{% endif %}
+{% if hasData %}
+
+{{accessModifier}} struct {{dataType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  @available(iOS 9.0, tvOS 9.0, watchOS 6.0, macOS 10.11, *)
+  {{accessModifier}} var data: NSDataAsset {
+    return NSDataAsset(asset: self)
+  }
+}
+
+@available(iOS 9.0, tvOS 9.0, watchOS 6.0, macOS 10.11, *)
+{{accessModifier}} extension NSDataAsset {
+  convenience init!(asset: {{dataType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(macOS)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+{% endif %}
+{% if hasImage %}
+
+{{accessModifier}} struct {{imageType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(macOS)
+  {{accessModifier}} typealias Image = NSImage
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Image = UIImage
+  #endif
+
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
+  {{accessModifier}} var image: Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  {{accessModifier}} func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
+}
+
+{{accessModifier}} extension {{imageType}}.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
+  @available(macOS, deprecated,
+    message: "This initializer is unsafe on macOS, please use the {{imageType}}.image property")
+  convenience init!(asset: {{imageType}}) {
+    #if os(iOS) || os(tvOS)
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+{% endif %}
+{% if hasSymbol %}
+
+{{accessModifier}} struct {{symbolType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(watchOS)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  {{accessModifier}} typealias Configuration = UIImage.SymbolConfiguration
+  {{accessModifier}} typealias Image = UIImage
+
+  @available(iOS 12.0, tvOS 12.0, watchOS 5.0, *)
+  {{accessModifier}} var image: Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else {
+      fatalError("Unable to load symbol asset named \(name).")
+    }
+    return result
+  }
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  {{accessModifier}} func image(with configuration: Configuration) -> Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    guard let result = Image(named: name, in: bundle, with: configuration) else {
+      fatalError("Unable to load symbol asset named \(name).")
+    }
+    return result
+  }
+  #endif
+}
+{% endif %}
+{% if not param.bundle %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No assets found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/xcassets/swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/xcassets/swift5.stencil
@@ -1,0 +1,437 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if catalogs %}
+{% macro hasValuesBlock assets filter %}
+  {%- for asset in assets -%}
+    {%- if asset.type == filter -%}
+      1
+    {%- elif asset.items -%}
+      {% call hasValuesBlock asset.items filter %}
+    {%- endif -%}
+  {%- endfor -%}
+{% endmacro %}
+{% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
+{% set arResourceGroupType %}{{param.arResourceGroupTypeName|default:"ARResourceGroupAsset"}}{% endset %}
+{% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
+{% set dataType %}{{param.dataTypeName|default:"DataAsset"}}{% endset %}
+{% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
+{% set symbolType %}{{param.symbolTypeName|default:"SymbolAsset"}}{% endset %}
+{% set forceNamespaces %}{{param.forceProvidesNamespaces|default:"false"}}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set hasARResourceGroup %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "arresourcegroup" %}{% endfor %}{% endset %}
+{% set hasColor %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "color" %}{% endfor %}{% endset %}
+{% set hasData %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "data" %}{% endfor %}{% endset %}
+{% set hasImage %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "image" %}{% endfor %}{% endset %}
+{% set hasSymbol %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "symbol" %}{% endfor %}{% endset %}
+#if os(macOS)
+  import AppKit
+#elseif os(iOS)
+{% if hasARResourceGroup %}
+  import ARKit
+{% endif %}
+  import UIKit
+#elseif os(tvOS) || os(watchOS)
+  import UIKit
+#endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
+
+// Deprecated typealiases
+{% if hasColor %}
+@available(*, deprecated, renamed: "{{colorType}}.Color", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.colorAliasName|default:"AssetColorTypeAlias"}} = {{colorType}}.Color
+{% endif %}
+{% if hasImage %}
+@available(*, deprecated, renamed: "{{imageType}}.Image", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.imageAliasName|default:"AssetImageTypeAlias"}} = {{imageType}}.Image
+{% endif %}
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Asset Catalogs
+
+{% macro enumBlock assets %}
+  {% call casesBlock assets %}
+  {% if param.allValues %}
+
+  // swiftlint:disable trailing_comma
+  {% set hasItems %}{% call hasValuesBlock assets "arresourcegroup" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allResourceGroups: [{{arResourceGroupType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "arresourcegroup" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "color" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allColors: [{{colorType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "color" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "data" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allDataAssets: [{{dataType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "data" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "image" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allImages: [{{imageType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "image" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "symbol" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allSymbols: [{{symbolType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "symbol" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  // swiftlint:enable trailing_comma
+  {% endif %}
+{% endmacro %}
+{% macro casesBlock assets %}
+  {% for asset in assets %}
+  {% if asset.type == "arresourcegroup" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{arResourceGroupType}}(name: "{{asset.value}}")
+  {% elif asset.type == "color" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{colorType}}(name: "{{asset.value}}")
+  {% elif asset.type == "data" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{dataType}}(name: "{{asset.value}}")
+  {% elif asset.type == "image" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{imageType}}(name: "{{asset.value}}")
+  {% elif asset.type == "symbol" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{symbolType}}(name: "{{asset.value}}")
+  {% elif asset.items and ( forceNamespaces == "true" or asset.isNamespaced == "true" ) %}
+  {{accessModifier}} enum {{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call casesBlock asset.items %}{% endfilter %}
+  }
+  {% elif asset.items %}
+  {% call casesBlock asset.items %}
+  {% endif %}
+  {% endfor %}
+{% endmacro %}
+{% macro allValuesBlock assets filter prefix %}
+  {% for asset in assets %}
+  {% if asset.type == filter %}
+  {{prefix}}{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}},
+  {% elif asset.items and ( forceNamespaces == "true" or asset.isNamespaced == "true" ) %}
+  {% set prefix2 %}{{prefix}}{{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.{% endset %}
+  {% call allValuesBlock asset.items filter prefix2 %}
+  {% elif asset.items %}
+  {% call allValuesBlock asset.items filter prefix %}
+  {% endif %}
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+{{accessModifier}} enum {{enumName}} {
+  {% if catalogs.count > 1 or param.forceFileNameEnum %}
+  {% for catalog in catalogs %}
+  {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% if catalog.assets %}
+    {% filter indent:2," ",true %}{% call enumBlock catalog.assets %}{% endfilter %}
+    {% endif %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call enumBlock catalogs.first.assets %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+{% if hasARResourceGroup %}
+
+{{accessModifier}} struct {{arResourceGroupType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(iOS)
+  @available(iOS 11.3, *)
+  {{accessModifier}} var referenceImages: Set<ARReferenceImage> {
+    return ARReferenceImage.referenceImages(in: self)
+  }
+
+  @available(iOS 12.0, *)
+  {{accessModifier}} var referenceObjects: Set<ARReferenceObject> {
+    return ARReferenceObject.referenceObjects(in: self)
+  }
+  #endif
+}
+
+#if os(iOS)
+@available(iOS 11.3, *)
+{{accessModifier}} extension ARReferenceImage {
+  static func referenceImages(in asset: {{arResourceGroupType}}) -> Set<ARReferenceImage> {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    return referenceImages(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+
+@available(iOS 12.0, *)
+{{accessModifier}} extension ARReferenceObject {
+  static func referenceObjects(in asset: {{arResourceGroupType}}) -> Set<ARReferenceObject> {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    return referenceObjects(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+#endif
+{% endif %}
+{% if hasColor %}
+
+{{accessModifier}} final class {{colorType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(macOS)
+  {{accessModifier}} typealias Color = NSColor
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Color = UIColor
+  #endif
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  {{accessModifier}} private(set) lazy var color: Color = {
+    guard let color = Color(asset: self) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }()
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 11.0, tvOS 11.0, *)
+  {{accessModifier}} func color(compatibleWith traitCollection: UITraitCollection) -> Color {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }
+  #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
+}
+
+{{accessModifier}} extension {{colorType}}.Color {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  convenience init?(asset: {{colorType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+{{accessModifier}} extension SwiftUI.Color {
+  init(asset: {{colorType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
+{% endif %}
+{% if hasData %}
+
+{{accessModifier}} struct {{dataType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  @available(iOS 9.0, tvOS 9.0, watchOS 6.0, macOS 10.11, *)
+  {{accessModifier}} var data: NSDataAsset {
+    guard let data = NSDataAsset(asset: self) else {
+      fatalError("Unable to load data asset named \(name).")
+    }
+    return data
+  }
+}
+
+@available(iOS 9.0, tvOS 9.0, watchOS 6.0, macOS 10.11, *)
+{{accessModifier}} extension NSDataAsset {
+  convenience init?(asset: {{dataType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(macOS)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+{% endif %}
+{% if hasImage %}
+
+{{accessModifier}} struct {{imageType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(macOS)
+  {{accessModifier}} typealias Image = NSImage
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Image = UIImage
+  #endif
+
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
+  {{accessModifier}} var image: Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  {{accessModifier}} func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
+}
+
+{{accessModifier}} extension {{imageType}}.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
+  @available(macOS, deprecated,
+    message: "This initializer is unsafe on macOS, please use the {{imageType}}.image property")
+  convenience init?(asset: {{imageType}}) {
+    #if os(iOS) || os(tvOS)
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+{{accessModifier}} extension SwiftUI.Image {
+  init(asset: {{imageType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: {{imageType}}, label: Text) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: {{imageType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
+{% endif %}
+{% if hasSymbol %}
+
+{{accessModifier}} struct {{symbolType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(watchOS)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  {{accessModifier}} typealias Configuration = UIImage.SymbolConfiguration
+  {{accessModifier}} typealias Image = UIImage
+
+  @available(iOS 12.0, tvOS 12.0, watchOS 5.0, *)
+  {{accessModifier}} var image: Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else {
+      fatalError("Unable to load symbol asset named \(name).")
+    }
+    return result
+  }
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  {{accessModifier}} func image(with configuration: Configuration) -> Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    guard let result = Image(named: name, in: bundle, with: configuration) else {
+      fatalError("Unable to load symbol asset named \(name).")
+    }
+    return result
+  }
+  #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
+}
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+{{accessModifier}} extension SwiftUI.Image {
+  init(asset: {{symbolType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: {{symbolType}}, label: Text) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: {{symbolType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
+{% endif %}
+{% if not param.bundle %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No assets found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/yaml/inline-swift4.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/yaml/inline-swift4.stencil
@@ -1,0 +1,92 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - YAML Files
+{% macro fileBlock file %}
+  {% if file.documents.count > 1 %}
+  {% for document in file.documents %}
+  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
+  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call documentBlock file document %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call documentBlock file file.documents.first %}
+  {% endif %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% elif document.metadata.type == "Dictionary" %}
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
+  {% endfor %}
+  {% else %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- elif metadata.type == "Optional" -%}
+    Any?
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
+    "{{ value }}"
+  {%- elif metadata.type == "Optional" -%}
+    nil
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
+      {{ ", " if not forloop.last }}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
+      {{ ", " if not forloop.last }}
+    {%- empty -%}
+      :
+    {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
+  {%- else -%}
+    {{ value }}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+{{accessModifier}} enum {{param.enumName|default:"YAMLFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/yaml/inline-swift5.stencil
+++ b/Packages/Tools/BuildPhasesPlugins/ArtifactBundles/swiftgen.artifactbundle/swiftgen/bin/SwiftGen_SwiftGenCLI.bundle/Contents/Resources/templates/yaml/inline-swift5.stencil
@@ -1,0 +1,92 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if files %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - YAML Files
+{% macro fileBlock file %}
+  {% if file.documents.count > 1 %}
+  {% for document in file.documents %}
+  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
+  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call documentBlock file document %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call documentBlock file file.documents.first %}
+  {% endif %}
+{% endmacro %}
+{% macro documentBlock file document %}
+  {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
+  {% if document.metadata.type == "Array" %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% elif document.metadata.type == "Dictionary" %}
+  {% for key,value in document.metadata.properties %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
+  {% endfor %}
+  {% else %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+  {% endif %}
+{% endmacro %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
+    [{% call typeBlock metadata.element %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [String: Any]
+  {%- elif metadata.type == "Optional" -%}
+    Any?
+  {%- else -%}
+    {{metadata.type}}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
+    "{{ value }}"
+  {%- elif metadata.type == "Optional" -%}
+    nil
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
+      {{ ", " if not forloop.last }}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
+      {{ ", " if not forloop.last }}
+    {%- empty -%}
+      :
+    {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
+  {%- else -%}
+    {{ value }}
+  {%- endif -%}
+{% endmacro %}
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+{{accessModifier}} enum {{param.enumName|default:"YAMLFiles"}} {
+  {% if files.count > 1 or param.forceFileNameEnum %}
+  {% for file in files %}
+  {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call fileBlock files.first %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length
+{% else %}
+// No files found
+{% endif %}

--- a/Packages/Tools/BuildPhasesPlugins/Package.swift
+++ b/Packages/Tools/BuildPhasesPlugins/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "BuildPhasesPlugins",
+    products: [
+        .plugin(name: "BuildPhasesPlugins", targets: ["BuildPhasesPlugins"]),
+        .library(name: "SwiftLint", targets: ["SwiftLint"])
+    ],
+    dependencies: [],
+    targets: [
+        .plugin(
+            name: "BuildPhasesPlugins",
+            capability: .buildTool(),
+            dependencies: [
+                .target(name: "SwiftLint"),
+                .target(name: "swiftgen")
+            ]
+        ),
+        .binaryTarget(
+            name: "SwiftLint",
+            path: "./ArtifactBundles/SwiftLint.artifactbundle"
+        ),
+        .binaryTarget(
+            name: "swiftgen",
+            path: "./ArtifactBundles/swiftgen.artifactbundle"
+        )
+    ]
+)

--- a/Packages/Tools/BuildPhasesPlugins/Plugins/BuildPhasesPlugins/BuildPhasesPlugins.swift
+++ b/Packages/Tools/BuildPhasesPlugins/Plugins/BuildPhasesPlugins/BuildPhasesPlugins.swift
@@ -1,0 +1,83 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct BuildPhasesPlugins: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        var commands = [Command]()
+        try commands.append(lintCommand(context: context, target: target))
+        try commands.append(contentsOf: swiftGenCommands(implementationTarget: target, in: context))
+        return commands
+    }
+
+    private func lintCommand(context: PluginContext, target: Target) throws -> Command {
+        let toolPath = try context.tool(named: "swiftlint")
+
+        return Command.prebuildCommand(
+            displayName: "Linting \(target.name)",
+            executable: toolPath.path,
+            arguments: [
+                "lint", // Run linting on the specified target
+                "--config", // Load the swiftlint rules
+                toolPath.path.removingLastComponent().removingLastComponent().appending("swiftlint.yml"),
+                "--cache-path", // Lint caching path
+                "/private/tmp",
+                target.directory.string
+            ],
+            outputFilesDirectory: context.pluginWorkDirectory
+        )
+    }
+
+    private func swiftGenCommands(implementationTarget target: Target, in context: PluginContext) throws -> [Command] {
+        let isImplementationModule = !(target.name.contains("Interface") || target.name.contains("Mocks") || target.name.contains("Tests"))
+        guard isImplementationModule else { return [] }
+
+        let executable = try context.tool(named: "swiftgen").path
+        let generatedFilesFolder = target.directory.appending("Generated")
+        var swiftGenCommands = [Command]()
+
+        // Find the english localizable file to build the strings from it
+        if let strings = try filePaths(in: target.directory.string, suffix: "en.lproj/Localizable.strings") {
+            if FileManager.default.fileExists(atPath: generatedFilesFolder.string) == false {
+                try FileManager.default.createDirectory(atPath: generatedFilesFolder.string, withIntermediateDirectories: true)
+            }
+
+            let inputFile = target.directory.appending(strings)
+            let content = try String(
+                contentsOf: .init(fileURLWithPath: inputFile.string),
+                encoding: .utf8
+            )
+            if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                let outputFiles = generatedFilesFolder.appending("Strings.swift")
+                swiftGenCommands.append(
+                    .prebuildCommand(
+                        displayName: "Swiftgen strings \(target.name)",
+                        executable: executable,
+                        arguments: [
+                            "run",
+                            "strings", // Specified generated . String in this case because we're generating localizables
+                            "--templateName",
+                            "structured-swift5", // This structres the generated file in enum and inner enums
+                            "--param", "enumName=Localizables", // This will make the main enum named `Localizables` instead of `L10n`
+                            "--param", "noComments", // This will not add any comments to the localizable file
+                            "--output", "\(generatedFilesFolder)/Strings.swift",
+                            inputFile
+                        ],
+                        outputFilesDirectory: outputFiles
+                    )
+                )
+            }
+        }
+
+        return swiftGenCommands
+    }
+
+    private func filePaths(in urlPath: String, suffix: String) throws -> String? {
+        FileManager.default
+            .enumerator(atPath: urlPath)?
+            .allObjects
+            .compactMap { $0 as? String }
+            .first { $0.hasSuffix(suffix) }
+    }
+}
+

--- a/Packages/Tools/BuildPhasesPlugins/README.md
+++ b/Packages/Tools/BuildPhasesPlugins/README.md
@@ -1,0 +1,22 @@
+# BuildPhasesPlugins Package
+The `BuildPhasesPlugins` package provides a Swift Package Manager plugin that generates build phases commands for linting and generating strings and assets files using SwiftLint and SwiftGen tools.
+
+You can install `BuildPhasesPlugins` using Swift Package Manager. To install it in your Xcode project, follow these steps:
+
+1. Click on File > Add Packages > Add Local.
+2. Select the directory that has the `Package.swift` file.
+3. Click Add Package.
+
+## Usage
+To use the `BuildPhasesPlugins` plugin, you need to add a` BuildToolPlugin` target in your `Package.swift` at the end of the file, as shown below:
+```swift
+.package(path: "../..Tools/BuildPhasesPlugins"),
+```
+
+The `createBuildCommands` function generates build phases commands for the specified target using the `lintCommand` and `swiftGenCommands` helper functions. The `lintCommand` function generates a command to run SwiftLint on the specified target, while the `swiftGenCommands` function generates commands to generate strings and assets files using SwiftGen.
+
+Acknowledgments
+The `BuildPhasesPlugins` package uses SwiftLint and SwiftGen tools to generate build phases commands.
+
+
+

--- a/alexandria.xcodeproj/project.pbxproj
+++ b/alexandria.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		907DDC582A475259006F3F72 /* alexandriaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907DDC572A475259006F3F72 /* alexandriaTests.swift */; };
 		907DDC622A475259006F3F72 /* alexandriaUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907DDC612A475259006F3F72 /* alexandriaUITests.swift */; };
 		907DDC642A475259006F3F72 /* alexandriaUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907DDC632A475259006F3F72 /* alexandriaUITestsLaunchTests.swift */; };
+		907DDC752A475613006F3F72 /* BuildPhasesPlugins in Resources */ = {isa = PBXBuildFile; fileRef = 907DDC742A475613006F3F72 /* BuildPhasesPlugins */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +45,7 @@
 		907DDC5D2A475259006F3F72 /* alexandriaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = alexandriaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		907DDC612A475259006F3F72 /* alexandriaUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = alexandriaUITests.swift; sourceTree = "<group>"; };
 		907DDC632A475259006F3F72 /* alexandriaUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = alexandriaUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		907DDC742A475613006F3F72 /* BuildPhasesPlugins */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = BuildPhasesPlugins; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,6 +76,7 @@
 		907DDC3A2A475258006F3F72 = {
 			isa = PBXGroup;
 			children = (
+				907DDC702A47558E006F3F72 /* Packages */,
 				907DDC452A475258006F3F72 /* alexandria */,
 				907DDC562A475259006F3F72 /* alexandriaTests */,
 				907DDC602A475259006F3F72 /* alexandriaUITests */,
@@ -125,6 +128,22 @@
 				907DDC632A475259006F3F72 /* alexandriaUITestsLaunchTests.swift */,
 			);
 			path = alexandriaUITests;
+			sourceTree = "<group>";
+		};
+		907DDC702A47558E006F3F72 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				907DDC712A47559A006F3F72 /* Tools */,
+			);
+			path = Packages;
+			sourceTree = "<group>";
+		};
+		907DDC712A47559A006F3F72 /* Tools */ = {
+			isa = PBXGroup;
+			children = (
+				907DDC742A475613006F3F72 /* BuildPhasesPlugins */,
+			);
+			path = Tools;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -232,6 +251,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				907DDC4E2A475258006F3F72 /* Preview Assets.xcassets in Resources */,
+				907DDC752A475613006F3F72 /* BuildPhasesPlugins in Resources */,
 				907DDC4B2A475258006F3F72 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
# BuildPhasesPlugins Package
The `BuildPhasesPlugins` package provides a Swift Package Manager plugin that generates build phases commands for linting and generating strings and assets files using SwiftLint and SwiftGen tools.

You can install `BuildPhasesPlugins` using Swift Package Manager. To install it in your Xcode project, follow these steps:

1. Click on File > Add Packages > Add Local.
2. Select the directory that has the `Package.swift` file.
3. Click Add Package.

## Usage
To use the `BuildPhasesPlugins` plugin, you need to add a` BuildToolPlugin` target in your `Package.swift` at the end of the file, as shown below:
```swift
.package(path: "../..Tools/BuildPhasesPlugins"),
```

The `createBuildCommands` function generates build phases commands for the specified target using the `lintCommand` and `swiftGenCommands` helper functions. The `lintCommand` function generates a command to run SwiftLint on the specified target, while the `swiftGenCommands` function generates commands to generate strings and assets files using SwiftGen.

Acknowledgments
The `BuildPhasesPlugins` package uses SwiftLint and SwiftGen tools to generate build phases commands.



