### PR TITLE
Added Github PR actions

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,7 +2,7 @@
 addReviewers: true
 
 # Set to true to add assignees to pull requests
-addAssignees: true
+addAssignees: author
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:

--- a/.github/pr-labeler-config.yml
+++ b/.github/pr-labeler-config.yml
@@ -1,0 +1,6 @@
+feature: ['feature/*','Feature/*']
+fix: ['fix/*', 'Fix/*']
+refactor: ['refactor/*', 'Refactor/*']
+ci: ['ci/*', 'CI/*']
+tools: ['tools/*', 'Tools/*']
+tests: ['tests/*', 'test/*', 'Test/*', 'Tests/*']

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,22 @@
+name: Pull Request Opened
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/pr-labeler-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  auto-assign:
+    if: github.head_ref != '_master/crowdin-translations'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.2
+        with:
+          configuration-path: .github/auto_assign_config.yml


### PR DESCRIPTION
**Pull Request Description**

**Changes in `.github/auto_assign.yml`:**

- Set the option to add reviewers to pull requests (`addReviewers`) to `true`.
- Set the option to add assignees to pull requests (`addAssignees`) to `true`.
- The pull requests will automatically assign the author (`addAssignees: author`) as an assignee.
- Added the following reviewers to be automatically assigned to pull requests:
  - ed-iune
  - tarekabdallah
- Skipped the process of adding reviewers if pull requests include the keywords `wip`.
- The number of reviewers added to the pull request is set to 1 (`numberOfReviewers: 1`).

**Changes in `.github/pr-labeler-config.yml`:**

- Updated the labeler configuration with the following mappings:
  - `feature`: ['feature/*', 'Feature/*']
  - `fix`: ['fix/*', 'Fix/*']
  - `refactor`: ['refactor/*', 'Refactor/*']
  - `ci`: ['ci/*', 'CI/*']
  - `tools`: ['tools/*', 'Tools/*']
  - `tests`: ['tests/*', 'test/*', 'Test/*', 'Tests/*']

**Changes in `.github/workflows/pull_request.yml`:**

- Created a workflow named "Pull Request Opened" that triggers on various pull request events (`opened`, `synchronize`, `reopened`, `ready_for_review`).
- Added a job named "pr-labeler" that runs on the latest version of Ubuntu.
- Configured the job to use the `TimonVS/pr-labeler-action@v3` action with the path `.github/pr-labeler-config.yml` for labeling pull requests.
- Set the environment variable `GITHUB_TOKEN` to the secret `GITHUB_TOKEN`.
- Added a job named "auto-assign" that runs on the latest version of Ubuntu.
- Configured the job to use the `kentaro-m/auto-assign-action@v1.1.2` action with the path `.github/auto_assign_config.yml`.
- Added a condition (`if: github.head_ref != '_master/crowdin-translations'`) to skip the auto-assign job for pull requests with the head reference `_master/crowdin-translations`.

These changes improve the pull request workflow by automatically assigning reviewers and labels based on the defined rules.